### PR TITLE
Postgres Support for ISS Key Storage + Docker Storage Support for the Firmware Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cov.xml
 cov_html
 htmlcov
 .pytest_cache
+local_blob_storage

--- a/docker-compose-addons.yml
+++ b/docker-compose-addons.yml
@@ -89,6 +89,7 @@ services:
       LOGGING_LEVEL: ${API_LOGGING_LEVEL}
     volumes:
       - ${GOOGLE_APPLICATION_CREDENTIALS}:/google/gcp_credentials.json
+      - ${HOST_BLOB_STORAGE_DIRECTORY}:/mnt/blob_storage
     logging:
       options:
         max-size: '10m'

--- a/resources/kubernetes/README.md
+++ b/resources/kubernetes/README.md
@@ -8,7 +8,7 @@ The webapp and API both utilize a K8s Ingress to handle external access to the a
 
 The YAML files use GCP specific specifications for various values such as "networking.gke.io/managed-certificates". These values will not work on AWS and Azure but there should be equivalent fields that these specifications can be updated to if needing to deploy in another cloud environment.
 
-The environment variables must be set according to the README documentation for each application. The iss-health-check application only supports GCP.
+The environment variables must be set according to the README documentation for each application. The iss-health-check application supports GCP or postgres for storing keys. The environment variables for the iss-health-check application must be set according to the README documentation for the iss-health-check application.
 
 ## Useful Links
 

--- a/resources/kubernetes/iss-health-check.yaml
+++ b/resources/kubernetes/iss-health-check.yaml
@@ -1,4 +1,4 @@
-# This deployment is only usable in a GCP environment due to the GCP Secret Manager dependency
+# If GCP is being used to store keys, this deployment will only be usable in a GCP environment due to the GCP Secret Manager dependency
 apiVersion: 'apps/v1'
 kind: 'Deployment'
 metadata:
@@ -27,6 +27,8 @@ spec:
           ports:
             - containerPort: 8080
           env:
+            - name: STORAGE_TYPE
+              value: GCP
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: '/home/secret/cv_credentials.json'
             - name: PROJECT_ID
@@ -40,6 +42,8 @@ spec:
             - name: ISS_SCMS_TOKEN_REST_ENDPOINT
               value: ''
             - name: ISS_SCMS_VEHICLE_REST_ENDPOINT
+              value: ''
+            - name: ISS_KEY_TABLE_NAME
               value: ''
             - name: DB_USER
               value: ''

--- a/resources/sql_scripts/CVManager_CreateTables.sql
+++ b/resources/sql_scripts/CVManager_CreateTables.sql
@@ -324,6 +324,21 @@ SELECT ro.rsu_id, org.name
 FROM public.rsu_organization AS ro
 JOIN public.organizations AS org ON ro.organization_id = org.organization_id;
 
+-- Create iss keys table (id, iss_key, creation_date, expiration_date)
+CREATE SEQUENCE public.iss_keys_iss_key_id_seq
+   INCREMENT 1
+   START 1
+   MINVALUE 1
+   MAXVALUE 2147483647
+   CACHE 1;
+
+CREATE TABLE IF NOT EXISTS public.iss_keys
+(
+   iss_key_id integer NOT NULL DEFAULT nextval('iss_keys_iss_key_id_seq'::regclass),
+   common_name character varying(128) COLLATE pg_catalog.default NOT NULL,
+   token character varying(128) COLLATE pg_catalog.default NOT NULL
+);
+
 -- Create scms_health table
 CREATE SEQUENCE public.scms_health_scms_health_id_seq
    INCREMENT 1

--- a/sample.env
+++ b/sample.env
@@ -87,9 +87,12 @@ MAPBOX_INIT_LONGITUDE="-104.9903"
 MAPBOX_INIT_ZOOM="10"
 
 # Firmware Manager
-BLOB_STORAGE_PROVIDER=GCP
-BLOB_STORAGE_BUCKET=
+BLOB_STORAGE_PROVIDER=DOCKER
+# GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
+BLOB_STORAGE_BUCKET=
+# Docker volume mount point for BLOB storage (if using Docker)
+HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # Levels are "DEBUG", "INFO", "WARNING", and "ERROR"
 API_LOGGING_LEVEL="INFO"

--- a/sample.env
+++ b/sample.env
@@ -87,11 +87,12 @@ MAPBOX_INIT_LONGITUDE="-104.9903"
 MAPBOX_INIT_ZOOM="10"
 
 # Firmware Manager
+## Provider of storage for firmware files (currently supported: GCP, DOCKER)
 BLOB_STORAGE_PROVIDER=DOCKER
-# GCP Project and Bucket for BLOB storage (if using GCP)
+## GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
 BLOB_STORAGE_BUCKET=
-# Docker volume mount point for BLOB storage (if using Docker)
+## Docker volume mount point for BLOB storage (if using Docker)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # Levels are "DEBUG", "INFO", "WARNING", and "ERROR"

--- a/services/addons/images/firmware_manager/README.md
+++ b/services/addons/images/firmware_manager/README.md
@@ -16,7 +16,7 @@ This directory contains a microservice that runs within the CV Manager GKE Clust
 
 An RSU is determined to be ready for upgrade if its entry in the "rsus" table in PostgreSQL has its "target_firmware_version" set to be different than its "firmware_version". The Firmware Manager will ignore all devices with incompatible firmware upgrades set as their target firmware based on the "firmware_upgrade_rules" table. The CV Manager API will only offer CV Manager webapp users compatible options so this generally is a precaution.
 
-Hosting firmware files is recommended to be done via the cloud. GCP cloud storage is the currently supported method. Alternatives can be added via the [download_blob.py](download_blob.py) script. Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
+Hosting firmware files is recommended to be done via the cloud. GCP cloud storage is the currently supported method, but a directory mounted as a docker volume can also be used. Alternative cloud support can be added via the [download_blob.py](download_blob.py) script. Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 
 Firmware upgrades have unique procedures based on RSU vendor/manufacturer. To avoid requiring a unique bash script for every single firmware upgrade, the Firmware Manager has been written to use vendor based upgrade scripts that have been thoroughly tested. An interface-like abstract class, [base_upgrader.py](base_upgrader.py), has been made for helping create upgrade scripts for vendors not yet supported. The Firmware Manager selects the script to use based off the RSU's "model" column in the "rsus" table. These scripts report back to the Firmware Manager on completion with a status of whether the upgrade was a success or failure. Regardless, the Firmware Manager will remove the process from its tracking and update the PostgreSQL database accordingly.
 
@@ -40,7 +40,7 @@ Available REST endpoints:
 
 To properly run the firmware_manager microservice the following services are also required:
 
-- Cloud based blob storage
+- Cloud based blob storage (if not using a directory mounted as a docker volume)
   - Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 - CV Manager PostgreSQL database with data in the "rsus", "rsu_models", "manufacturers", "firmware_images", and "firmware_upgrade_rules" tables
 - Network connectivity from the environment the firmware_manager is deployed into to the blob storage and the RSUs
@@ -59,6 +59,9 @@ GCP Required environment variables:
 
 - GCP_PROJECT - GCP project for the firmware cloud storage bucket
 - GOOGLE_APPLICATION_CREDENTIALS - Service account location. Recommended to attach as a volume.
+
+Docker volume required environment variables:
+- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage
 
 ## Vendor Specific Requirements
 

--- a/services/addons/images/firmware_manager/README.md
+++ b/services/addons/images/firmware_manager/README.md
@@ -40,7 +40,7 @@ Available REST endpoints:
 
 To properly run the firmware_manager microservice the following services are also required:
 
-- Cloud based blob storage (if not using a directory mounted as a docker volume)
+- Blob storage (cloud-based or otherwise)
   - Firmware storage must be organized by: `vendor/rsu-model/firmware-version/install_package`.
 - CV Manager PostgreSQL database with data in the "rsus", "rsu_models", "manufacturers", "firmware_images", and "firmware_upgrade_rules" tables
 - Network connectivity from the environment the firmware_manager is deployed into to the blob storage and the RSUs
@@ -61,7 +61,7 @@ GCP Required environment variables:
 - GOOGLE_APPLICATION_CREDENTIALS - Service account location. Recommended to attach as a volume.
 
 Docker volume required environment variables:
-- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage
+- HOST_BLOB_STORAGE_DIRECTORY - Directory mounted as a docker volume for firmware storage. A relative path can be specified here.
 
 ## Vendor Specific Requirements
 

--- a/services/addons/images/firmware_manager/download_blob.py
+++ b/services/addons/images/firmware_manager/download_blob.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 
-# Only supports GCP Bucket Storage for downloading blobs
+# Download a blob from GCP Bucket Storage
 def download_gcp_blob(blob_name, destination_file_name):
     gcp_project = os.environ.get("GCP_PROJECT")
     bucket_name = os.environ.get("BLOB_STORAGE_BUCKET")
@@ -13,4 +13,14 @@ def download_gcp_blob(blob_name, destination_file_name):
     blob.download_to_filename(destination_file_name)
     logging.info(
         f"Downloaded storage object {blob_name} from bucket {bucket_name} to local file {destination_file_name}."
+    )
+
+
+# "Download" a blob from a directory mounted as a volume in a Docker container
+def download_docker_blob(blob_name, destination_file_name):
+    directory = "/mnt/blob_storage"
+    source_file_name = f"{directory}/{blob_name}"
+    os.system(f"cp {source_file_name} {destination_file_name}")
+    logging.info(
+        f"Copied storage object {blob_name} from directory {directory} to local file {destination_file_name}."
     )

--- a/services/addons/images/firmware_manager/download_blob.py
+++ b/services/addons/images/firmware_manager/download_blob.py
@@ -3,8 +3,14 @@ import logging
 import os
 
 
-# Download a blob from GCP Bucket Storage
 def download_gcp_blob(blob_name, destination_file_name):
+    """Download a file from a GCP Bucket Storage bucket to a local file.
+
+    Args:
+        blob_name (str): The name of the file in the bucket.
+        destination_file_name (str): The name of the local file to download the bucket file to.
+    """
+
     gcp_project = os.environ.get("GCP_PROJECT")
     bucket_name = os.environ.get("BLOB_STORAGE_BUCKET")
     storage_client = storage.Client(gcp_project)
@@ -16,8 +22,14 @@ def download_gcp_blob(blob_name, destination_file_name):
     )
 
 
-# "Download" a blob from a directory mounted as a volume in a Docker container
 def download_docker_blob(blob_name, destination_file_name):
+    """Copy a file from a directory mounted as a volume in a Docker container to a local file.
+
+    Args:
+        blob_name (str): The name of the file in the directory.
+        destination_file_name (str): The name of the local file to copy the directory file to.
+    """
+    
     directory = "/mnt/blob_storage"
     source_file_name = f"{directory}/{blob_name}"
     os.system(f"cp {source_file_name} {destination_file_name}")

--- a/services/addons/images/firmware_manager/download_blob.py
+++ b/services/addons/images/firmware_manager/download_blob.py
@@ -11,6 +11,8 @@ def download_gcp_blob(blob_name, destination_file_name):
         destination_file_name (str): The name of the local file to download the bucket file to.
     """
 
+    validate_file_type(blob_name)
+
     gcp_project = os.environ.get("GCP_PROJECT")
     bucket_name = os.environ.get("BLOB_STORAGE_BUCKET")
     storage_client = storage.Client(gcp_project)
@@ -29,10 +31,27 @@ def download_docker_blob(blob_name, destination_file_name):
         blob_name (str): The name of the file in the directory.
         destination_file_name (str): The name of the local file to copy the directory file to.
     """
-    
+
+    validate_file_type(blob_name)
+
     directory = "/mnt/blob_storage"
     source_file_name = f"{directory}/{blob_name}"
     os.system(f"cp {source_file_name} {destination_file_name}")
     logging.info(
         f"Copied storage object {blob_name} from directory {directory} to local file {destination_file_name}."
     )
+
+def validate_file_type(file_name):
+    """Validate the file type of the file to be downloaded.
+
+    Args:
+        file_name (str): The name of the file to be downloaded.
+    """
+    if not file_name.endswith(".tar"):
+        logging.error(f"Unsupported file type for storage object {file_name}. Only .tar files are supported.")
+        raise UnsupportedFileTypeException
+
+class UnsupportedFileTypeException(Exception):
+    def __init__(self, message="Unsupported file type. Only .tar files are supported."):
+        self.message = message
+        super().__init__(self.message)

--- a/services/addons/images/firmware_manager/sample.env
+++ b/services/addons/images/firmware_manager/sample.env
@@ -7,8 +7,12 @@ PG_DB_USER=""
 PG_DB_PASS=""
 
 # Blob storage variables
-BLOB_STORAGE_PROVIDER="GCP"
-BLOB_STORAGE_BUCKET=""
+BLOB_STORAGE_PROVIDER=DOCKER
+# GCP Project and Bucket for BLOB storage (if using GCP)
+GCP_PROJECT=
+BLOB_STORAGE_BUCKET=
+# Docker volume mount point for BLOB storage (if using Docker)
+HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # For users using GCP cloud storage
 GCP_PROJECT=""

--- a/services/addons/images/firmware_manager/sample.env
+++ b/services/addons/images/firmware_manager/sample.env
@@ -6,12 +6,12 @@ PG_DB_NAME=""
 PG_DB_USER=""
 PG_DB_PASS=""
 
-# Blob storage variables
+# Blob storage variables (only 'GCP' and 'DOCKER' are supported at this time)
 BLOB_STORAGE_PROVIDER=DOCKER
 ## GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
 BLOB_STORAGE_BUCKET=
-## Docker volume mount point for BLOB storage (if using Docker)
+## Docker volume mount point for BLOB storage (if using DOCKER)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # For users using GCP cloud storage

--- a/services/addons/images/firmware_manager/sample.env
+++ b/services/addons/images/firmware_manager/sample.env
@@ -8,10 +8,10 @@ PG_DB_PASS=""
 
 # Blob storage variables
 BLOB_STORAGE_PROVIDER=DOCKER
-# GCP Project and Bucket for BLOB storage (if using GCP)
+## GCP Project and Bucket for BLOB storage (if using GCP)
 GCP_PROJECT=
 BLOB_STORAGE_BUCKET=
-# Docker volume mount point for BLOB storage (if using Docker)
+## Docker volume mount point for BLOB storage (if using Docker)
 HOST_BLOB_STORAGE_DIRECTORY=./local_blob_storage
 
 # For users using GCP cloud storage

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -40,6 +40,7 @@ class UpgraderAbstractClass(abc.ABC):
             download_blob.download_docker_blob(self.blob_name, self.local_file_name)
         else:
             logging.error("Unsupported blob storage provider")
+            raise StorageProviderNotSupportedException
 
     # Notifies the firmware manager of the completion status for the upgrade
     # success is a boolean
@@ -60,3 +61,7 @@ class UpgraderAbstractClass(abc.ABC):
     @abc.abstractclassmethod
     def upgrade(self):
         pass
+
+class StorageProviderNotSupportedException(Exception):
+    def __init__(self):
+        super().__init__("Unsupported blob storage provider")

--- a/services/addons/images/firmware_manager/upgrader.py
+++ b/services/addons/images/firmware_manager/upgrader.py
@@ -33,9 +33,11 @@ class UpgraderAbstractClass(abc.ABC):
         Path(path).mkdir(exist_ok=True)
 
         # Download blob, defaults to GCP blob storage
-        bsp = os.environ.get("BLOB_STORAGE_PROVIDER", "GCP")
-        if bsp == "GCP":
+        bspCaseInsensitive = os.environ.get("BLOB_STORAGE_PROVIDER", "DOCKER").casefold()
+        if bspCaseInsensitive == "gcp":
             download_blob.download_gcp_blob(self.blob_name, self.local_file_name)
+        elif bspCaseInsensitive == "docker":
+            download_blob.download_docker_blob(self.blob_name, self.local_file_name)
         else:
             logging.error("Unsupported blob storage provider")
 

--- a/services/addons/images/iss_health_check/README.md
+++ b/services/addons/images/iss_health_check/README.md
@@ -11,15 +11,15 @@
 
 This directory contains a microservice that runs within the CV Manager GKE Cluster. The iss_health_checker application populates the CV Manager PostGreSQL database's 'scms_health' table with the current ISS SCMS statuses of all RSUs recorded in the 'rsus' table. These statuses are queried by this application from a provided ISS Green Hills SCMS API endpoint.
 
-The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys are stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
+The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys can be stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
 
-Currently only GCP is supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application for secret manager equivalent support for other cloud environments.
+Currently only GCP & Postgres are supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
 
 ## Requirements <a name = "requirements"></a>
 
 To properly run the iss_health_checker microservice the following services are also required:
 
-- GCP project and service account with GCP Secret Manager access
+- GCP project and service account with GCP Secret Manager access (only required if STORAGE_TYPE is set to 'gcp')
 - CV Manager PostgreSQL database with at least one RSU inserted into the 'rsus' table
 - Service agreement with ISS Green Hills to have access to the SCMS API REST service endpoint
 - iss_health_checker must be deployed in the same environment or K8s cluster as the PostgreSQL database
@@ -27,7 +27,9 @@ To properly run the iss_health_checker microservice the following services are a
 
 The iss_health_checker microservice expects the following environment variables to be set:
 
-- GOOGLE_APPLICATION_CREDENTIALS - file location for GCP JSON service account key.
+- STORAGE_TYPE - Storage solution for the SCMS API access keys. Currently only 'gcp' & 'postgres' are supported.
+- GOOGLE_APPLICATION_CREDENTIALS - File location for GCP JSON service account key. Only required if STORAGE_TYPE is set to 'gcp'.
+- ISS_KEY_TABLE_NAME - Postgres table name for the ISS SCMS API access keys. Only required if STORAGE_TYPE is set to 'postgres'.
 - PROJECT_ID - GCP project ID.
 - ISS_API_KEY - Initial ISS SCMS API access key to perform the first run of the script. This access key must not expire before the first runtime.
 - ISS_API_KEY_NAME - Human readable reference for the access key within ISS SCMS API. Generated access keys will utilize this same name.

--- a/services/addons/images/iss_health_check/README.md
+++ b/services/addons/images/iss_health_check/README.md
@@ -13,7 +13,7 @@ This directory contains a microservice that runs within the CV Manager GKE Clust
 
 The application schedules the iss_health_checker script to run every 6 hours. A new SCMS API access key is generated every run of the script to ensure the access never expires. This is due to a limitation of the SCMS API not allowing permanent access keys. Access keys can be stored in GCP Secret Manager to allow for versioning and encrypted storage. The application removes the previous access key from the SCMS API after runtime to reduce clutter of access keys on the API service account.
 
-Currently only GCP & Postgres are supported to run this application due to a reliance on the GCP Secret Manager. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
+Currently GCP & Postgres are the only supported storage solutions to run this application. Storing the access keys on a local volume is not recommended due to security vulnerabilities. Feel free to contribute to this application to support other storage solutions.
 
 ## Requirements <a name = "requirements"></a>
 

--- a/services/addons/images/iss_health_check/iss_health_checker.py
+++ b/services/addons/images/iss_health_check/iss_health_checker.py
@@ -92,6 +92,12 @@ def insert_scms_data(data):
         'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES'
     )
     for value in data.values():
+        try:
+            value["deviceHealth"]
+        except KeyError:
+            logging.warning("deviceHealth not found in data for RSU with id {}, is it real data?".format(value["rsu_id"]))
+            continue
+
         health = "1" if value["deviceHealth"] == "Healthy" else "0"
         if value["expiration"]:
             query = (

--- a/services/addons/images/iss_health_check/iss_health_checker.py
+++ b/services/addons/images/iss_health_check/iss_health_checker.py
@@ -95,10 +95,7 @@ def insert_scms_data(data):
         'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES'
     )
     for value in data.values():
-        try:
-            value["deviceHealth"]
-        except KeyError:
-            logger.warning("deviceHealth not found in data for RSU with id {}, is it real data?".format(value["rsu_id"]))
+        if validate_scms_data(value) is False:
             continue
 
         health = "1" if value["deviceHealth"] == "Healthy" else "0"
@@ -114,6 +111,33 @@ def insert_scms_data(data):
     logger.info(
         "SCMS data inserted {} messages into PostgreSQL...".format(len(data.values()))
     )
+
+def validate_scms_data(value):
+    """Validate the SCMS data
+    
+    Args:
+        value (dict): SCMS data
+    """
+    
+    try:
+        value["rsu_id"]
+    except KeyError as e:
+        logger.warning("rsu_id not found in data, is it real data? exception: {}".format(e))
+        return False
+
+    try:
+        value["deviceHealth"]
+    except KeyError as e:
+        logger.warning("deviceHealth not found in data for RSU with id {}, is it real data? exception: {}".format(value["rsu_id"], e))
+        return False
+
+    try:
+        value["expiration"]
+    except KeyError as e:
+        logger.warning("expiration not found in data for RSU with id {}, is it real data? exception: {}".format(value["rsu_id"], e))
+        return False
+    
+    return True
 
 
 if __name__ == "__main__":

--- a/services/addons/images/iss_health_check/iss_health_checker.py
+++ b/services/addons/images/iss_health_check/iss_health_checker.py
@@ -167,7 +167,7 @@ if __name__ == "__main__":
     log_level = (
         "INFO" if "LOGGING_LEVEL" not in os.environ else os.environ["LOGGING_LEVEL"]
     )
-    logger.basicConfig(format="%(levelname)s:%(message)s", level=log_level)
+    logging.basicConfig(format="%(levelname)s:%(message)s", level=log_level)
 
     scms_statuses = get_scms_status_data()
     insert_scms_data(scms_statuses)

--- a/services/addons/images/iss_health_check/iss_health_checker.py
+++ b/services/addons/images/iss_health_check/iss_health_checker.py
@@ -107,7 +107,8 @@ def insert_scms_data(data):
         else:
             query = query + f" ('{now_ts}', '{health}', NULL, {value['rsu_id']}),"
 
-    pgquery.write_db(query[:-1])
+    query = query[:-1] # remove comma
+    pgquery.write_db(query)
     logger.info(
         "SCMS data inserted {} messages into PostgreSQL...".format(len(data.values()))
     )
@@ -118,7 +119,7 @@ def validate_scms_data(value):
     Args:
         value (dict): SCMS data
     """
-    
+
     try:
         value["rsu_id"]
     except KeyError as e:

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -10,13 +10,19 @@ import logging
 def get_storage_type():
     """Get the storage type for the ISS SCMS API token
     """
+    try :
+        os.environ["STORAGE_TYPE"]
+    except KeyError:
+        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        return "gcp"
+    
     if os.environ["STORAGE_TYPE"] == "gcp":
         return "gcp"
     elif os.environ["STORAGE_TYPE"] == "postgres":
         return "postgres"
     else:
         # default to gcp
-        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        logging.debug("STORAGE_TYPE environment variable not recognized, defaulting to gcp")
         return "gcp"
 
 

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -184,7 +184,11 @@ def get_token():
     # Create new ISS SCMS API Token to ensure its freshness
     logging.debug("POST: " + iss_base)
     response = requests.post(iss_base, json=iss_post_body, headers=iss_headers)
-    new_token = response.json()["Item"]
+    try:
+        new_token = response.json()["Item"]
+    except requests.JSONDecodeError:
+        logging.error("Failed to decode JSON response from ISS SCMS API. Response: " + response.text)
+        exit(1)
     logging.debug(f"Received new token: {new_friendly_name}")
 
     if data_exists:

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -16,9 +16,10 @@ def get_storage_type():
         logging.error("STORAGE_TYPE environment variable not set, exiting")
         exit(1)
     
-    if os.environ["STORAGE_TYPE"] == "gcp":
+    storageTypeCaseInsensitive = os.environ["STORAGE_TYPE"].casefold()
+    if storageTypeCaseInsensitive == "gcp":
         return "gcp"
-    elif os.environ["STORAGE_TYPE"] == "postgres":
+    elif storageTypeCaseInsensitive == "postgres":
         return "postgres"
     else:
         logging.error("STORAGE_TYPE environment variable not set to a valid value, exiting")

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -13,17 +13,16 @@ def get_storage_type():
     try :
         os.environ["STORAGE_TYPE"]
     except KeyError:
-        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
-        return "gcp"
+        logging.error("STORAGE_TYPE environment variable not set, exiting")
+        exit(1)
     
     if os.environ["STORAGE_TYPE"] == "gcp":
         return "gcp"
     elif os.environ["STORAGE_TYPE"] == "postgres":
         return "postgres"
     else:
-        # default to gcp
-        logging.debug("STORAGE_TYPE environment variable not recognized, defaulting to gcp")
-        return "gcp"
+        logging.error("STORAGE_TYPE environment variable not set to a valid value, exiting")
+        exit(1)
 
 
 # GCP Secret Manager functions

--- a/services/addons/images/iss_health_check/iss_token.py
+++ b/services/addons/images/iss_health_check/iss_token.py
@@ -1,11 +1,26 @@
 from google.cloud import secretmanager
+import common.pgquery as pgquery
 import requests
 import os
 import json
 import uuid
 import logging
 
+# Get storage type from environment variable
+def get_storage_type():
+    """Get the storage type for the ISS SCMS API token
+    """
+    if os.environ["STORAGE_TYPE"] == "gcp":
+        return "gcp"
+    elif os.environ["STORAGE_TYPE"] == "postgres":
+        return "postgres"
+    else:
+        # default to gcp
+        logging.debug("STORAGE_TYPE environment variable not set, defaulting to gcp")
+        return "gcp"
 
+
+# GCP Secret Manager functions
 def create_secret(client, secret_id, parent):
     """Create a new GCP secret in GCP Secret Manager
     client: GCP Security Manager client
@@ -66,26 +81,89 @@ def add_secret_version(client, secret_id, parent, data):
     logging.debug("New version added")
 
 
-def get_token():
-    client = secretmanager.SecretManagerServiceClient()
-    secret_id = "iss-token-secret"
-    parent = f"projects/{os.environ['PROJECT_ID']}"
-
-    # Check to see if the GCP secret exists
-    secret_exists = check_if_secret_exists(client, secret_id, parent)
-
-    if secret_exists:
-        # Grab the latest token data
-        value = get_latest_secret_version(client, secret_id, parent)
-        friendly_name = value["name"]
-        token = value["token"]
-        logging.debug(f"Received token: {friendly_name}")
+# Postgres functions
+def check_if_data_exists(table_name):
+    """Check if data exists in the table
+    table_name: name of the table
+    """
+    # create the query
+    query = f"SELECT * FROM {table_name}"
+    # execute the query
+    data = pgquery.query_db(query)
+    # check if data exists
+    if len(data) > 0:
+        return True
     else:
-        # If there is no available ISS token secret, create secret
-        logging.debug("Secret does not exist, creating secret")
-        create_secret(client, secret_id, parent)
-        # Use environment variable for first run with new secret
-        token = os.environ["ISS_API_KEY"]
+        return False
+
+
+def get_latest_data(table_name):
+    """Get latest value of a token from the table
+    table_name: name of the table
+    """
+    # create the query
+    query = f"SELECT * FROM {table_name} ORDER BY iss_key_id DESC LIMIT 1"
+    # execute the query
+    data = pgquery.query_db(query)
+    # return the data
+    toReturn = {}
+    toReturn["id"] = data[0][0] # id
+    toReturn["name"] = data[0][1] # common_name
+    toReturn["token"] = data[0][2] # token
+    logging.debug(f"Received token: {toReturn['name']} with id {toReturn['id']}")
+    return toReturn
+
+
+def add_data(table_name, common_name, token):
+    """Add a new token to the table
+    table_name: name of the table
+    data: String value for the new token
+    """
+    # create the query
+    query = f"INSERT INTO {table_name} (common_name, token) VALUES ('{common_name}', '{token}')"
+    # execute the query
+    pgquery.write_db(query)
+
+
+# Main function
+def get_token():
+    storage_type = get_storage_type()
+    if storage_type == "gcp":
+        client = secretmanager.SecretManagerServiceClient()
+        secret_id = "iss-token-secret"
+        parent = f"projects/{os.environ['PROJECT_ID']}"
+
+        # Check to see if the GCP secret exists
+        data_exists = check_if_secret_exists(client, secret_id, parent)
+
+        if data_exists:
+            # Grab the latest token data
+            value = get_latest_secret_version(client, secret_id, parent)
+            friendly_name = value["name"]
+            token = value["token"]
+            logging.debug(f"Received token: {friendly_name}")
+        else:
+            # If there is no available ISS token secret, create secret
+            logging.debug("Secret does not exist, creating secret")
+            create_secret(client, secret_id, parent)
+            # Use environment variable for first run with new secret
+            token = os.environ["ISS_API_KEY"]
+    elif storage_type == "postgres":
+        key_table_name = os.environ["ISS_KEY_TABLE_NAME"]
+        
+        # check to see if data exists in the table
+        data_exists = check_if_data_exists(key_table_name)
+
+        if data_exists:
+            # grab the latest token data
+            value = get_latest_data(key_table_name)
+            id = value["id"]
+            friendly_name = value["name"]
+            token = value["token"]
+            logging.debug(f"Received token: {friendly_name} with id {id}")
+        else:
+            # if there is no data, use environment variable for first run
+            token = os.environ["ISS_API_KEY"]
 
     # Pull new ISS SCMS API token
     iss_base = os.environ["ISS_SCMS_TOKEN_REST_ENDPOINT"]
@@ -103,7 +181,7 @@ def get_token():
     new_token = response.json()["Item"]
     logging.debug(f"Received new token: {new_friendly_name}")
 
-    if secret_exists:
+    if data_exists:
         # If exists, delete previous API key to prevent key clutter
         iss_delete_body = {"friendlyName": friendly_name}
         requests.delete(iss_base, json=iss_delete_body, headers=iss_headers)
@@ -111,6 +189,11 @@ def get_token():
 
     version_data = {"name": new_friendly_name, "token": new_token}
 
-    add_secret_version(client, secret_id, parent, version_data)
+    if get_storage_type() == "gcp":
+        # Add new version to the secret
+        add_secret_version(client, secret_id, parent, version_data)
+    elif get_storage_type() == "postgres":
+        # add new entry to the table
+        add_data(key_table_name, new_friendly_name, new_token)
 
     return new_token

--- a/services/addons/images/iss_health_check/sample.env
+++ b/services/addons/images/iss_health_check/sample.env
@@ -12,9 +12,19 @@ PG_DB_NAME=
 PG_DB_USER=
 PG_DB_PASS=
 
-# GCP Project ID and service account JSON key file location (mount as volume or secret)
+# Key Storage
+## Type of key storage, options: gcp, postgres
+STORAGE_TYPE=
+
+## GCP Storage (Required if STORAGE_TYPE=gcp)
+### GCP Project ID
 PROJECT_ID=
+### Service account JSON key file location (mount as volume or secret)
 GOOGLE_APPLICATION_CREDENTIALS=
+
+## Postgres Storage (Required if STORAGE_TYPE=postgres)
+### Table name to store keys
+ISS_KEY_TABLE_NAME=
 
 # Customize the logging level, defaults to INFO
 # Options: DEBUG, INFO, WARN, ERROR (case sensitive)

--- a/services/addons/tests/firmware_manager/test_download_blob.py
+++ b/services/addons/tests/firmware_manager/test_download_blob.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock, patch
 import os
+import pytest
 
 from addons.images.firmware_manager import download_blob
+from addons.images.firmware_manager.download_blob import UnsupportedFileTypeException
 
 
 @patch.dict(
@@ -17,24 +19,42 @@ def test_download_gcp_blob(mock_storage_client, mock_logging):
 
     # run
     download_blob.download_gcp_blob(
-        blob_name="test.blob", destination_file_name="/home/test/"
+        blob_name="test.tar", destination_file_name="/home/test/"
     )
 
     # validate
     mock_storage_client.assert_called_with("test-project")
     mock_client.get_bucket.assert_called_with("test-bucket")
-    mock_bucket.blob.assert_called_with("test.blob")
+    mock_bucket.blob.assert_called_with("test.tar")
     mock_blob.download_to_filename.assert_called_with("/home/test/")
     mock_logging.info.assert_called_with(
-        "Downloaded storage object test.blob from bucket test-bucket to local file /home/test/."
+        "Downloaded storage object test.tar from bucket test-bucket to local file /home/test/."
     )
+
+@patch.dict(
+    os.environ, {"GCP_PROJECT": "test-project", "BLOB_STORAGE_BUCKET": "test-bucket"}
+)
+def test_download_gcp_blob_unsupported_file_type():
+    # prepare
+    blob_name = "test.blob"
+    destination_file_name = "/home/test/"
+
+    # run
+    with pytest.raises(UnsupportedFileTypeException):
+        download_blob.download_gcp_blob(blob_name, destination_file_name)
+
+        # validate
+        os.system.assert_not_called()
+        mock_logging.error.assert_called_with(
+            f"Unsupported file type for storage object {blob_name}. Only .tar files are supported."
+        )
 
 
 @patch("addons.images.firmware_manager.download_blob.logging")
 def test_download_docker_blob(mock_logging):
     # prepare
     os.system = MagicMock()
-    blob_name = "test.blob"
+    blob_name = "test.tar"
     destination_file_name = "/home/test/"
 
     # run
@@ -46,3 +66,20 @@ def test_download_docker_blob(mock_logging):
         f"Copied storage object {blob_name} from directory /mnt/blob_storage to local file {destination_file_name}."
     )
 
+
+@patch("addons.images.firmware_manager.download_blob.logging")
+def test_download_docker_blob_unsupported_file_type(mock_logging):
+    # prepare
+    os.system = MagicMock()
+    blob_name = "test.blob"
+    destination_file_name = "/home/test/"
+
+    # run
+    with pytest.raises(UnsupportedFileTypeException):
+        download_blob.download_docker_blob(blob_name, destination_file_name)
+
+        # validate
+        os.system.assert_not_called()
+        mock_logging.error.assert_called_with(
+            f"Unsupported file type for storage object {blob_name}. Only .tar files are supported."
+        )

--- a/services/addons/tests/firmware_manager/test_download_blob.py
+++ b/services/addons/tests/firmware_manager/test_download_blob.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import os
 
 from addons.images.firmware_manager import download_blob
@@ -28,3 +28,21 @@ def test_download_gcp_blob(mock_storage_client, mock_logging):
     mock_logging.info.assert_called_with(
         "Downloaded storage object test.blob from bucket test-bucket to local file /home/test/."
     )
+
+
+@patch("addons.images.firmware_manager.download_blob.logging")
+def test_download_docker_blob(mock_logging):
+    # prepare
+    os.system = MagicMock()
+    blob_name = "test.blob"
+    destination_file_name = "/home/test/"
+
+    # run
+    download_blob.download_docker_blob(blob_name, destination_file_name)
+
+    # validate
+    os.system.assert_called_with(f"cp /mnt/blob_storage/{blob_name} {destination_file_name}")
+    mock_logging.info.assert_called_with(
+        f"Copied storage object {blob_name} from directory /mnt/blob_storage to local file {destination_file_name}."
+    )
+

--- a/services/addons/tests/firmware_manager/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_upgrader.py
@@ -85,6 +85,21 @@ def test_download_blob_gcp(mock_Path, mock_download_gcp_blob):
         "/home/8.8.8.8/firmware_package.tar",
     )
 
+@patch.dict(os.environ, {"BLOB_STORAGE_PROVIDER": "DOCKER"})
+@patch("addons.images.firmware_manager.upgrader.download_blob.download_docker_blob")
+@patch("addons.images.firmware_manager.upgrader.Path")
+def test_download_blob_docker(mock_Path, mock_download_docker_blob):
+    mock_path_obj = mock_Path.return_value
+    test_upgrader = TestUpgrader(test_upgrade_info)
+
+    test_upgrader.download_blob()
+
+    mock_path_obj.mkdir.assert_called_with(exist_ok=True)
+    mock_download_docker_blob.assert_called_with(
+        "test-manufacturer/test-model/1.0.0/firmware_package.tar",
+        "/home/8.8.8.8/firmware_package.tar",
+    )
+
 
 @patch.dict(os.environ, {"BLOB_STORAGE_PROVIDER": "Test"})
 @patch("addons.images.firmware_manager.upgrader.logging")

--- a/services/addons/tests/firmware_manager/test_upgrader.py
+++ b/services/addons/tests/firmware_manager/test_upgrader.py
@@ -1,7 +1,9 @@
 from unittest.mock import patch
 import os
+import pytest
 
 from addons.images.firmware_manager import upgrader
+from addons.images.firmware_manager.upgrader import StorageProviderNotSupportedException
 
 
 # Test class for testing the abstract class
@@ -109,11 +111,12 @@ def test_download_blob_not_supported(mock_Path, mock_download_gcp_blob, mock_log
     mock_path_obj = mock_Path.return_value
     test_upgrader = TestUpgrader(test_upgrade_info)
 
-    test_upgrader.download_blob()
+    with pytest.raises(StorageProviderNotSupportedException):
+        test_upgrader.download_blob()
 
-    mock_path_obj.mkdir.assert_called_with(exist_ok=True)
-    mock_download_gcp_blob.assert_not_called()
-    mock_logging.error.assert_called_with("Unsupported blob storage provider")
+        mock_path_obj.mkdir.assert_called_with(exist_ok=True)
+        mock_download_gcp_blob.assert_not_called()
+        mock_logging.error.assert_called_with("Unsupported blob storage provider")
 
 
 @patch("addons.images.firmware_manager.upgrader.logging")

--- a/services/addons/tests/iss_health_check/test_iss_health_checker.py
+++ b/services/addons/tests/iss_health_check/test_iss_health_checker.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 import os
 
 from addons.images.iss_health_check import iss_health_checker
+from addons.images.iss_health_check.iss_health_checker import RsuDataWrapper
 
 
 @patch("addons.images.iss_health_check.iss_health_checker.pgquery.query_db")
@@ -10,7 +11,8 @@ def test_get_rsu_data_no_data(mock_query_db):
     result = iss_health_checker.get_rsu_data()
 
     # check
-    assert result == {}
+    expected = RsuDataWrapper({})
+    assert result == expected
     mock_query_db.assert_called_once()
     mock_query_db.assert_called_with(
         "SELECT jsonb_build_object('rsu_id', rsu_id, 'iss_scms_id', iss_scms_id) FROM public.rsus WHERE iss_scms_id IS NOT NULL ORDER BY rsu_id"
@@ -27,7 +29,7 @@ def test_get_rsu_data_with_data(mock_query_db):
     ]
     result = iss_health_checker.get_rsu_data()
 
-    expected_result = {"ABC": {"rsu_id": 1}, "DEF": {"rsu_id": 2}, "GHI": {"rsu_id": 3}}
+    expected_result = RsuDataWrapper({"ABC": {"rsu_id": 1}, "DEF": {"rsu_id": 2}, "GHI": {"rsu_id": 3}})
 
     # check
     assert result == expected_result
@@ -52,7 +54,7 @@ def test_get_rsu_data_with_data(mock_query_db):
 def test_get_scms_status_data(
     mock_get_rsu_data, mock_get_token, mock_requests, mock_response
 ):
-    mock_get_rsu_data.return_value = {"ABC": {"rsu_id": 1}, "DEF": {"rsu_id": 2}}
+    mock_get_rsu_data.return_value = RsuDataWrapper({"ABC": {"rsu_id": 1}, "DEF": {"rsu_id": 2}})
     mock_get_token.get_token.return_value = "test-token"
     mock_requests.get.return_value = mock_response
     mock_response.json.side_effect = [

--- a/services/addons/tests/iss_health_check/test_iss_health_checker.py
+++ b/services/addons/tests/iss_health_check/test_iss_health_checker.py
@@ -141,3 +141,66 @@ def test_insert_scms_data(mock_write_db, mock_datetime):
         "('2022-11-03T00:00:00.000Z', '0', NULL, 2)"
     )
     mock_write_db.assert_called_with(expectedQuery)
+
+
+@patch("addons.images.iss_health_check.iss_health_checker.datetime")
+@patch("addons.images.iss_health_check.iss_health_checker.pgquery.write_db")
+def test_insert_scms_data_no_rsu_id(mock_write_db, mock_datetime):
+    mock_datetime.strftime.return_value = "2022-11-03T00:00:00.000Z"
+    test_data = {
+        "ABC": {
+            "deviceHealth": "Healthy",
+            "expiration": "2022-11-02T00:00:00.000Z",
+        },
+        "DEF": {"rsu_id": 2, "deviceHealth": "Unhealthy", "expiration": None},
+    }
+    # call
+    iss_health_checker.insert_scms_data(test_data)
+
+    expectedQuery = (
+        'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES '
+        "('2022-11-03T00:00:00.000Z', '0', NULL, 2)"
+    )
+    mock_write_db.assert_called_with(expectedQuery)
+
+
+@patch("addons.images.iss_health_check.iss_health_checker.datetime")
+@patch("addons.images.iss_health_check.iss_health_checker.pgquery.write_db")
+def test_insert_scms_data_no_deviceHealth(mock_write_db, mock_datetime):
+    mock_datetime.strftime.return_value = "2022-11-03T00:00:00.000Z"
+    test_data = {
+        "ABC": {
+            "rsu_id": 1,
+            "expiration": "2022-11-02T00:00:00.000Z",
+        },
+        "DEF": {"rsu_id": 2, "deviceHealth": "Unhealthy", "expiration": None},
+    }
+    # call
+    iss_health_checker.insert_scms_data(test_data)
+
+    expectedQuery = (
+        'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES '
+        "('2022-11-03T00:00:00.000Z', '0', NULL, 2)"
+    )
+    mock_write_db.assert_called_with(expectedQuery)
+
+
+@patch("addons.images.iss_health_check.iss_health_checker.datetime")
+@patch("addons.images.iss_health_check.iss_health_checker.pgquery.write_db")
+def test_insert_scms_data_no_expiration(mock_write_db, mock_datetime):
+    mock_datetime.strftime.return_value = "2022-11-03T00:00:00.000Z"
+    test_data = {
+        "ABC": {
+            "rsu_id": 1,
+            "deviceHealth": "Healthy",
+        },
+        "DEF": {"rsu_id": 2, "deviceHealth": "Unhealthy", "expiration": "test"},
+    }
+    # call
+    iss_health_checker.insert_scms_data(test_data)
+
+    expectedQuery = (
+        'INSERT INTO public.scms_health("timestamp", health, expiration, rsu_id) VALUES '
+        "('2022-11-03T00:00:00.000Z', '0', 'test', 2)"
+    )
+    mock_write_db.assert_called_with(expectedQuery)

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -2,6 +2,8 @@ from unittest.mock import patch, MagicMock
 import os
 import json
 
+import pytest
+
 from addons.images.iss_health_check import iss_token
 
 # --------------------- Storage Type tests ---------------------
@@ -57,11 +59,8 @@ def test_get_storage_type_postgres_case_insensitive():
     },
 )
 def test_get_storage_type_invalid():
-    try:
+    with pytest.raises(SystemExit):
         iss_token.get_storage_type()
-        assert False
-    except SystemExit:
-        assert True
 
 
 @patch.dict(
@@ -71,11 +70,8 @@ def test_get_storage_type_invalid():
     },
 )
 def test_get_storage_type_unset():
-    try:
+    with pytest.raises(SystemExit):
         iss_token.get_storage_type()
-        assert False
-    except SystemExit:
-        assert True
 
 # --------------------- end of Storage Type tests ---------------------
     

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -34,9 +34,11 @@ def test_get_storage_type_postgres():
     },
 )
 def test_get_storage_type_invalid():
-    expected_default = "gcp"
-    actual_value = iss_token.get_storage_type()
-    assert actual_value == expected_default
+    try:
+        iss_token.get_storage_type()
+        assert False
+    except SystemExit:
+        assert True
 
 
 @patch.dict(
@@ -46,9 +48,11 @@ def test_get_storage_type_invalid():
     },
 )
 def test_get_storage_type_unset():
-    expected_default = "gcp"
-    actual_value = iss_token.get_storage_type()
-    assert actual_value == expected_default
+    try:
+        iss_token.get_storage_type()
+        assert False
+    except SystemExit:
+        assert True
 
 # --------------------- end of Storage Type tests ---------------------
     

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -98,6 +98,7 @@ def test_add_secret_version(mock_sm_client):
         "ISS_API_KEY": "test-api-key",
         "ISS_SCMS_TOKEN_REST_ENDPOINT": "https://api.dm.iss-scms.com/api/test-token",
         "ISS_API_KEY_NAME": "test-api-key-name",
+        "STORAGE_TYPE": "gcp",
     },
 )
 @patch("addons.images.iss_health_check.iss_token.requests.Response")
@@ -162,6 +163,7 @@ def test_get_token_create_secret(
         "ISS_API_KEY": "test-api-key",
         "ISS_SCMS_TOKEN_REST_ENDPOINT": "https://api.dm.iss-scms.com/api/test-token",
         "ISS_API_KEY_NAME": "test-api-key-name",
+        "STORAGE_TYPE": "gcp",
     },
 )
 @patch("addons.images.iss_health_check.iss_token.requests.Response")

--- a/services/addons/tests/iss_health_check/test_iss_token.py
+++ b/services/addons/tests/iss_health_check/test_iss_token.py
@@ -27,6 +27,29 @@ def test_get_storage_type_postgres():
     actual_value = iss_token.get_storage_type()
     assert actual_value == "postgres"
 
+
+@patch.dict(
+    os.environ,
+    {
+        "STORAGE_TYPE": "GCP",
+    },
+)
+def test_get_storage_type_gcp_case_insensitive():
+    actual_value = iss_token.get_storage_type()
+    assert actual_value == "gcp"
+
+
+@patch.dict(
+    os.environ,
+    {
+        "STORAGE_TYPE": "POSTGRES",
+    },
+)
+def test_get_storage_type_postgres_case_insensitive():
+    actual_value = iss_token.get_storage_type()
+    assert actual_value == "postgres"
+
+
 @patch.dict(
     os.environ,
     {

--- a/services/requirements.txt
+++ b/services/requirements.txt
@@ -23,7 +23,7 @@ gunicorn==21.2.0
 pytz==2023.3.post1
 Werkzeug==3.0.0
 uuid==1.30
-multidict==6.0.4
+multidict==6.0.5
 python-keycloak==2.16.2
 fabric==3.2.2
 paramiko==3.3.1


### PR DESCRIPTION
# Postgres Support for ISS Key Storage
## Problem
The ISS Health Checker is currently only capable of using GCP to store its keys.

## Solution
Support has been added for storing keys using the existing PGSQL database instead of GCP.

## Testing
- Unit tests for postgres storage were added & verified to be passing
- This has been deployed on WYDOT's Test VM and the logs indicate it is working.

# Docker Storage Support for the Firmware Manager
## Problem
The Firmware Manager addon currently only supports storing firmware files in GCP. In a deployment where this isn't desired, we need another way to store the firmware files.

## Solution
Support for storing firmware files in a directory mounted as a docker volume has been added to the project.

## Testing
- Unit tests pass with these changes.
- This has been deployed on WYDOT's Test VM.
- Program starts up correctly & checks for firmware upgrades as expected.
- Initiating a firmware upgrade for Trihydro's Test Bed RSU was successful.