### PR TITLE
Fix issue with TLS and Auth requirements not defaulting to True

### DIFF
--- a/services/addons/images/count_metric/daily_emailer.py
+++ b/services/addons/images/count_metric/daily_emailer.py
@@ -42,16 +42,9 @@ def query_mongo_in_counts(rsu_dict, start_dt, end_dt, mongo_db):
 
             logging.debug(f"{type.title()} In count received for {rsu_ip}: {count}")
 
-            # If a RSU that is not in PostgreSQL has counts recorded, add it to the rsu_dict and populate zeroes
-            if rsu_ip not in rsu_dict:
-                rsu_dict[rsu_ip] = {
-                    "primary_route": "Unknown",
-                    "counts": {},
-                }
-                for t in message_types:
-                    rsu_dict[rsu_ip]["counts"][t] = {"in": 0, "out": 0}
-
-            rsu_dict[rsu_ip]["counts"][type]["in"] = count
+            # If the RSU is a part of the organization, add it to the rsu_dict
+            if rsu_ip in rsu_dict:
+                rsu_dict[rsu_ip]["counts"][type]["in"] = count
 
 
 # Modify the rsu_dict with the specified date range's mongoDB "out" counts for each message type
@@ -86,16 +79,9 @@ def query_mongo_out_counts(rsu_dict, start_dt, end_dt, mongo_db):
 
             logging.debug(f"{type.title()} Out count received for {rsu_ip}: {count}")
 
-            # If a RSU that is not in PostgreSQL has counts recorded, add it to the rsu_dict and populate zeroes
-            if rsu_ip not in rsu_dict:
-                rsu_dict[rsu_ip] = {
-                    "primary_route": "Unknown",
-                    "counts": {},
-                }
-                for t in message_types:
-                    rsu_dict[rsu_ip]["counts"][t] = {"in": 0, "out": 0}
-
-            rsu_dict[rsu_ip]["counts"][type]["out"] = count
+            # If the RSU is a part of the organization, add it to the rsu_dict
+            if rsu_ip in rsu_dict:
+                rsu_dict[rsu_ip]["counts"][type]["out"] = count
 
 
 def prepare_org_rsu_dict():

--- a/services/addons/tests/count_metric/test_daily_emailer.py
+++ b/services/addons/tests/count_metric/test_daily_emailer.py
@@ -51,8 +51,7 @@ def test_query_mongo_in_counts():
         ]
     )
     assert rsu_dict["10.0.0.1"]["counts"]["BSM"]["in"] == 5
-    assert rsu_dict["10.0.0.2"]["counts"]["BSM"]["in"] == 25
-    assert rsu_dict["10.0.0.2"]["primary_route"] == "Unknown"
+    assert len(rsu_dict) == 1
 
     daily_emailer.message_types = ["BSM", "TIM", "Map", "SPaT", "SRM", "SSM"]
 
@@ -134,8 +133,7 @@ def test_query_mongo_out_counts():
         ]
     )
     assert rsu_dict["10.0.0.1"]["counts"]["BSM"]["out"] == 5
-    assert rsu_dict["10.0.0.2"]["counts"]["BSM"]["out"] == 25
-    assert rsu_dict["10.0.0.2"]["primary_route"] == "Unknown"
+    assert len(rsu_dict) == 1
 
     daily_emailer.message_types = ["BSM", "TIM", "Map", "SPaT", "SRM", "SSM"]
 

--- a/services/common/emailSender.py
+++ b/services/common/emailSender.py
@@ -21,20 +21,16 @@ class EmailSender:
         username,
         password,
         pretty=False,
-        tlsEnabled=False,
-        authEnabled=False,
+        tlsEnabled="true",
+        authEnabled="true",
     ):
         try:
             # prepare email
             toSend = ""
             if pretty:
-                toSend = self.formatPretty(
-                    sender, recipient, subject, message
-                )
+                toSend = self.formatPretty(sender, recipient, subject, message)
             else:
-                toSend = self.format(
-                    recipient, subject, message, replyEmail
-                )
+                toSend = self.format(recipient, subject, message, replyEmail)
 
             if tlsEnabled == "true":
                 self.server.starttls(context=self.context)  # start TLS encryption
@@ -58,7 +54,12 @@ Subject: %s
 %s
 
 Please reply to %s.
-""" % (recipient, subject, message, replyEmail)
+""" % (
+            recipient,
+            subject,
+            message,
+            replyEmail,
+        )
         return toReturn
 
     def formatPretty(self, sender, recipient, subject, html_message):


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This pull requests modifies the email sender to default the use of TLS and Auth to true instead of false. This ensures the CV Manager is defaulting to the most secure email methodologies and is backwards compatible to older deployments of the CV Manager. 

The count emails have now been modified to not display unknown RSUs since it isn't desirable to have unknown RSUs displayed in count emails where there is an expected small subset of RSUs. This prevents situations leading to email recipients being confused by unknown RSUs that may not even be within their jurisdiction.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested locally with unit tests and deployed in GCP GKE.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
