### PR TITLE
Fixing User Creation Timestamp Bug

### DIFF
--- a/services/api/src/admin_new_user.py
+++ b/services/api/src/admin_new_user.py
@@ -2,6 +2,7 @@ import logging
 import common.pgquery as pgquery
 import sqlalchemy
 import os
+import time
 
 
 def query_and_return_list(query):
@@ -89,9 +90,10 @@ def add_user(user_spec):
         }, 500
 
     try:
+        current_timestamp = int(time.time() * 1000)
         user_insert_query = (
-            "INSERT INTO public.users(email, first_name, last_name, super_user) "
-            f"VALUES ('{user_spec['email']}', '{user_spec['first_name']}', '{user_spec['last_name']}', '{'1' if user_spec['super_user'] else '0'}')"
+            "INSERT INTO public.users(email, first_name, last_name, super_user, created_timestamp) "
+            f"VALUES ('{user_spec['email']}', '{user_spec['first_name']}', '{user_spec['last_name']}', '{'1' if user_spec['super_user'] else '0'}', {current_timestamp})"
         )
         pgquery.write_db(user_insert_query)
 

--- a/webapp/src/features/adminOrganizationTabIntersection/AdminOrganizationTabIntersection.tsx
+++ b/webapp/src/features/adminOrganizationTabIntersection/AdminOrganizationTabIntersection.tsx
@@ -114,6 +114,10 @@ const AdminOrganizationTabIntersection = (props: AdminOrganizationTabIntersectio
   }
 
   const intersectionMultiAdd = async (intersectionList: AdminOrgIntersection[]) => {
+    if (intersectionList.length === 0) {
+      toast.error('Please select intersections to add')
+      return
+    }
     dispatch(intersectionAddMultiple({ intersectionList, selectedOrg, selectedOrgEmail, updateTableData })).then(
       (data) => {
         if (!(data.payload as any).success) {

--- a/webapp/src/features/adminOrganizationTabRsu/AdminOrganizationTabRsu.tsx
+++ b/webapp/src/features/adminOrganizationTabRsu/AdminOrganizationTabRsu.tsx
@@ -114,6 +114,10 @@ const AdminOrganizationTabRsu = (props: AdminOrganizationTabRsuProps) => {
   }
 
   const rsuMultiAdd = async (rsuList: AdminOrgRsu[]) => {
+    if (rsuList.length === 0) {
+      toast.error('Please select RSUs to add')
+      return
+    }
     dispatch(rsuAddMultiple({ rsuList, selectedOrg, selectedOrgEmail, updateTableData })).then((data) => {
       if (!(data.payload as any).success) {
         toast.error((data.payload as any).message)

--- a/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
+++ b/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
@@ -203,6 +203,10 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
   }
 
   const userMultiAdd = async (userList: AdminOrgUser[]) => {
+    if (userList.length === 0) {
+      toast.error('Please select users to add.')
+      return
+    }
     dispatch(
       userAddMultiple({
         userList,

--- a/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
+++ b/webapp/src/features/adminOrganizationTabUser/AdminOrganizationTabUser.tsx
@@ -204,7 +204,7 @@ const AdminOrganizationTabUser = (props: AdminOrganizationTabUserProps) => {
 
   const userMultiAdd = async (userList: AdminOrgUser[]) => {
     if (userList.length === 0) {
-      toast.error('Please select users to add.')
+      toast.error('Please select users to add')
       return
     }
     dispatch(


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

This PR fixes the following bugs:
- [x] While on dashboard/admin/users, going through the "+" button to add users failed because the API was trying to create users without a "created_timestamp"
    - [x] The API now creates users with the current time as the "created_timestamp"  
![image](https://github.com/user-attachments/assets/322e1960-02dd-4ff8-b0c7-2e4abfe8a319)

- [x] While on dashboard/admin/organizations, if the sub-item "+" button to add RSUs, Intersections, or Users was pressed without any items, the request would fail
    - [x] Multi-add logic now catches empty lists and returns a toast message to the user
![image](https://github.com/user-attachments/assets/4fcc9e04-11a9-404c-9a51-1628a692eb09)


## How Has This Been Tested?

This was tested locally. Here are the steps to test each bug:
### New user created_timestamp missing
1. Navigate to the dashboard/admin/users page (Admin page, Users tab)
2. Press the "+" create new user button at the top right
3. Enter an email, first name, last name, and select an organization to join
4. Press "Add User"
5. Expected result: Green toast message reading "User added successfully", and the CV Manager Users table should now include the new user

### Multi-add empty list
1. Navigate to the dashboard/admin/organizations page (Admin, Organizations tab)
2. Open one of the sub-items (RSUs, Intersections, or Users)
3. Leaving the "Click to add *" multi-select box empty, select the "+" icon
4. Expected result: Red toast message reading "Please select * to add"

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [ ] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
