### PR TITLE
Hotfix/2.0.1: Update V2X Message Viewer Schema Validation

### DIFF
--- a/docs/Release_notes.md
+++ b/docs/Release_notes.md
@@ -1,5 +1,15 @@
 ## JPO CV Manager Release Notes
 
+## Version 2.0.1
+
+### **Summary**
+
+In this hotfix, the V2X message viewer backend functionality has been modified to be compatible with the latest jpo-geojsonconverter output.
+
+Enhancements in this release:
+
+- [USDOT PR 60](https://github.com/usdot-jpo-ode/jpo-cvmanager/pull/60): Hotfix/2.0.1: Update V2X Message Viewer Schema Validation
+
 ## Version 2.0.0
 
 This version introduces updates across both backend and frontend components, enhancing system performance, reliability, and user experience. This release includes a complete rework of SNMP message forwarding, upgraded authentication with Keycloak 26, and refactored Intersection API endpoints with the new reworked jpo-geojsonconverter's (3.1.0) processed message output. The update also streamlines standalone deployments and adds new interface improvements such as toast notifications and updated visualization tools. Numerous bug fixes, dependency cleanups, and UI refinements have also been made.

--- a/services/api/src/rsu_geo_msg_query.py
+++ b/services/api/src/rsu_geo_msg_query.py
@@ -100,7 +100,7 @@ def query_geo_data_mongo(pointList, start, end, msg_type):
         logging.debug(f"Returned records: {num_docs}")
 
         for doc in collection.find(filter=filter):
-            if doc["properties"]["schemaVersion"] != 8:
+            if doc["properties"]["schemaVersion"] != 2:
                 logging.warning(
                     f"Skipping message with schema version {doc['properties']['schemaVersion']}"
                 )

--- a/services/api/tests/data/rsu_geo_msg_query_data.py
+++ b/services/api/tests/data/rsu_geo_msg_query_data.py
@@ -35,7 +35,7 @@ mongo_geo_bsm_data_response = [
         "type": "Feature",
         "properties": {
             "validationMessages": [],
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "secMark": 1000,
             "heading": 1000,
             "brakes": {
@@ -81,7 +81,7 @@ mongo_geo_psm_data_response = [
         "geometry": {"type": "Point", "coordinates": [-105.0, 40.0]},
         "type": "Feature",
         "properties": {
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "messageType": "PSM",
             "odeReceivedAt": datetime.datetime.now(pytz.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
@@ -116,7 +116,7 @@ mongo_geo_data_not_time_sorted = [
         "geometry": {"type": "Point", "coordinates": [-105.0, 40.0]},
         "type": "Feature",
         "properties": {
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "messageType": "",
             "odeReceivedAt": (
                 datetime.datetime.now(pytz.utc) - datetime.timedelta(hours=2)
@@ -135,7 +135,7 @@ mongo_geo_data_not_time_sorted = [
         "geometry": {"type": "Point", "coordinates": [-105.0, 40.0]},
         "type": "Feature",
         "properties": {
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "messageType": "",
             "odeReceivedAt": datetime.datetime.now(pytz.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
@@ -150,7 +150,7 @@ mongo_geo_data_not_time_sorted = [
         "geometry": {"type": "Point", "coordinates": [-105.0, 40.0]},
         "type": "Feature",
         "properties": {
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "messageType": "",
             "odeReceivedAt": datetime.datetime.now(pytz.utc).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
@@ -165,7 +165,7 @@ mongo_geo_data_not_time_sorted = [
         "geometry": {"type": "Point", "coordinates": [-105.0, 40.0]},
         "type": "Feature",
         "properties": {
-            "schemaVersion": 8,
+            "schemaVersion": 2,
             "messageType": "",
             "odeReceivedAt": (
                 datetime.datetime.now(pytz.utc) - datetime.timedelta(hours=1)


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

<!--- Describe your changes in detail -->
Includes fix for the V2X message viewer to not expect messages with schema version 8 and instead correctly verifies schema version 2. This corresponds to the latest jpo-geojsonconverter output.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally and in CDOT's GCP environment.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [x] I have modified/added tests to cover my changes.
- [x] All existing tests pass.
