### PR TITLE
Rsu Status Visualization

### DIFF
--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/rsuState/RsuStateRepository.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/rsuState/RsuStateRepository.java
@@ -1,0 +1,15 @@
+package us.dot.its.jpo.ode.api.accessors.rsuState;
+
+import java.util.List;
+import us.dot.its.jpo.ode.api.models.snmp.RsuState;
+import us.dot.its.jpo.ode.api.models.DataLoader;
+
+public interface RsuStateRepository extends DataLoader<RsuState> {
+    List<RsuState> retrieveRsuStateWithinTimeInterval(String rsuIP, long start, long end);
+
+    List<RsuState> findByRsuIPOrderByTimestampDesc(String rsuIP);
+
+    List<RsuState> retrieveRsuStateWithinTimeInterval(String rsuIP, long start, long end,
+            int intervalMinutes);
+
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/rsuState/RsuStateRepositoryImpl.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/accessors/rsuState/RsuStateRepositoryImpl.java
@@ -1,0 +1,86 @@
+package us.dot.its.jpo.ode.api.accessors.rsuState;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+import java.util.Date;
+import org.bson.Document;
+
+import us.dot.its.jpo.ode.api.models.snmp.RsuState;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+@Component
+public class RsuStateRepositoryImpl implements RsuStateRepository {
+
+    private final MongoTemplate mongoTemplate;
+    private final String collectionName = "IntersectionApiRsuStatus";
+
+    @Autowired
+    public RsuStateRepositoryImpl(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void add(RsuState item) {
+        mongoTemplate.insert(item, collectionName);
+    }
+
+    @Override
+    public List<RsuState> retrieveRsuStateWithinTimeInterval(String rsuIP, long start, long end) {
+        Criteria criteria = Criteria.where("rsuIP").is(rsuIP)
+                .and("timestamp").gte(new Date(start)).lte(new Date(end));
+        Query query = Query.query(criteria).with(Sort.by(Sort.Direction.ASC, "timestamp"));
+        return mongoTemplate.find(query, RsuState.class, collectionName);
+    }
+
+    @Override
+    public List<RsuState> retrieveRsuStateWithinTimeInterval(String rsuIP, long start, long end, int intervalMinutes) {
+        long intervalMs = intervalMinutes * 60 * 1000; // Convert minutes to milliseconds
+
+        Criteria criteria = Criteria.where("rsuIP").is(rsuIP)
+                .and("timestamp").gte(new Date(start)).lte(new Date(end));
+
+        Aggregation aggregation = Aggregation.newAggregation(
+                Aggregation.match(criteria), // filter by rsuIP and timestamp
+                Aggregation.project("timestamp", "rsuIP", "temperature", "uptime", "mode")
+                        .andExpression("{$convert: {input: \"$timestamp\", to: \"long\"}}").as("timestampMillis"),
+                Aggregation.project("timestamp", "rsuIP", "temperature", "uptime", "mode", "timestampMillis")
+                        .andExpression("timestampMillis - (timestampMillis % " + intervalMs + ")").as("interval"),
+                Aggregation.group("interval") // Group by interval
+                        .avg("temperature").as("temperature")
+                        .avg("uptime").as("uptime")
+                        .first("rsuIP").as("rsuIP")
+                        .first("mode").as("mode")
+                        .first("timestamp").as("timestamp"),
+                Aggregation.sort(Sort.by(Sort.Direction.ASC, "timestamp")) // Sort by timestamp
+        );
+
+        System.out.println("[RSU Status] Aggregation Pipeline: " + aggregation.toString());
+
+        List<RsuState> results = mongoTemplate.aggregate(aggregation, collectionName, RsuState.class)
+                .getMappedResults();
+
+        return results;
+    }
+
+    @Override
+    public List<RsuState> findByRsuIPOrderByTimestampDesc(String rsuIP) {
+        Criteria criteria = Criteria.where("rsuIP").is(rsuIP);
+        Query query = Query.query(criteria).with(Sort.by(Sort.Direction.DESC, "timestamp"));
+
+        List<RsuState> results = mongoTemplate.find(query, RsuState.class, collectionName);
+        return results;
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/RsuController.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/controllers/data/RsuController.java
@@ -1,0 +1,90 @@
+package us.dot.its.jpo.ode.api.controllers.data;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import us.dot.its.jpo.ode.api.models.snmp.RsuState;
+import us.dot.its.jpo.ode.api.accessors.rsuState.RsuStateRepository;
+
+import java.util.List;
+
+@RestController
+@ConditionalOnProperty(name = "enable.api", havingValue = "true", matchIfMissing = false)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "401", description = "Unauthorized"),
+        @ApiResponse(responseCode = "500", description = "Internal Server Error")
+})
+@RequestMapping("/data/rsu-status")
+public class RsuController {
+
+    private final RsuStateRepository rsuStateRepository;
+
+    @Autowired
+    public RsuController(RsuStateRepository rsuStateRepository) {
+        this.rsuStateRepository = rsuStateRepository;
+    }
+
+    @Operation(summary = "Get historical RSU Status", description = "Returns all RSU status records for the given RSU IP and time range (UTC ms)")
+    @GetMapping(value = "/historical", produces = "application/json")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+            @ApiResponse(responseCode = "400", description = "Invalid parameters")
+    })
+    public ResponseEntity<List<RsuState>> getHistoricalRsuStatus(
+            @RequestParam String rsuIp,
+            @RequestParam long startTime,
+            @RequestParam long endTime) {
+        if (startTime > endTime) {
+            return ResponseEntity.badRequest().build();
+        }
+        List<RsuState> results = rsuStateRepository.retrieveRsuStateWithinTimeInterval(rsuIp, startTime, endTime);
+        return ResponseEntity.ok(results);
+    }
+
+    @Operation(summary = "Get latest RSU Status", description = "Returns the most recent RSU status record for the given RSU IP")
+    @GetMapping(value = "/latest", produces = "application/json")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+            @ApiResponse(responseCode = "404", description = "No RSU status found for this RSU IP")
+    })
+    public ResponseEntity<RsuState> getLatestRsuStatus(@RequestParam String rsuIp) {
+        List<RsuState> results = rsuStateRepository.findByRsuIPOrderByTimestampDesc(rsuIp);
+        if (!results.isEmpty()) {
+            RsuState latest = results.get(0);
+            return ResponseEntity.ok(latest);
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @Operation(summary = "Get aggregated RSU Status", description = "Returns aggregated RSU status records for the given RSU IP and time range (UTC ms)")
+    @GetMapping(value = "/aggregated", produces = "application/json")
+    @PreAuthorize("@PermissionService.isSuperUser() || @PermissionService.hasRole('USER')")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Success"),
+            @ApiResponse(responseCode = "403", description = "Forbidden - Requires SUPER_USER or USER role"),
+            @ApiResponse(responseCode = "400", description = "Invalid parameters")
+    })
+    public ResponseEntity<List<RsuState>> getAggregatedRsuStatus(
+            @RequestParam String rsuIp,
+            @RequestParam long startTime,
+            @RequestParam long endTime,
+            @RequestParam int intervalMinutes) {
+        if (startTime > endTime || intervalMinutes <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
+        List<RsuState> results = rsuStateRepository.retrieveRsuStateWithinTimeInterval(rsuIp, startTime,
+                endTime, intervalMinutes);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/snmp/RsuState.java
+++ b/services/intersection-api/api/src/main/java/us/dot/its/jpo/ode/api/models/snmp/RsuState.java
@@ -1,0 +1,39 @@
+package us.dot.its.jpo.ode.api.models.snmp;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class RsuState {
+    /**
+     * Time in UTC Milliseconds that the RSU State was generated
+     */
+    public long timestamp;
+
+    /**
+     * IntersectionID of the intersection corresponding to the RSU
+     */
+    public String intersectionID;
+
+    /**
+     * IP Address of the RSU unit
+     */
+    public String rsuIP;
+
+    /**
+     * Internal Temperature of the RSU Unit
+     */
+    public double temperature;
+
+    /**
+     * Time in seconds since the RSU unit last rebooted
+     */
+    public Long uptime;
+
+    /**
+     * The Mode of the RSU. There are 3 common modes, Operational(4), Standby (2)
+     * and Off (16)
+     */
+    public Long mode;
+}

--- a/webapp/src/apis/intersections/rsu-api.ts
+++ b/webapp/src/apis/intersections/rsu-api.ts
@@ -1,0 +1,105 @@
+import { authApiHelper } from './api-helper-cviz'
+
+// TypeScript type for RSU State (should match your backend model)
+export type RsuState = {
+  timestamp: number
+  intersectionID: string
+  rsuIP: string
+  temperature: number
+  uptime: number
+  mode: number
+}
+
+class RsuApi {
+  // Fetch historical RSU states for a given RSU IP and time range
+  async getHistoricalRsuStatus({
+    token,
+    rsuIp,
+    startTime,
+    endTime,
+    abortController,
+  }: {
+    token: string
+    rsuIp: string
+    startTime: Date
+    endTime: Date
+    abortController?: AbortController
+  }): Promise<RsuState[] | undefined> {
+    const queryParams: Record<string, string> = {
+      rsuIp,
+      startTime: startTime.getTime().toString(),
+      endTime: endTime.getTime().toString(),
+    }
+
+    const response = await authApiHelper.invokeApi({
+      path: `/data/rsu-status/historical`,
+      token,
+      queryParams,
+      abortController,
+      failureMessage: 'Failed to fetch historical RSU status',
+      tag: 'rsu',
+    })
+
+    return response
+  }
+
+  // Fetch the latest RSU state for a given RSU IP
+  async getLatestRsuStatus({
+    token,
+    rsuIp,
+    abortController,
+  }: {
+    token: string
+    rsuIp: string
+    abortController?: AbortController
+  }): Promise<RsuState | undefined> {
+    const queryParams: Record<string, string> = { rsuIp }
+
+    const response = await authApiHelper.invokeApi({
+      path: `/data/rsu-status/latest`,
+      token,
+      queryParams,
+      abortController,
+      failureMessage: 'Failed to fetch latest RSU status',
+      tag: 'rsu',
+    })
+
+    return response
+  }
+
+  async getAggregatedRsuStatus({
+    token,
+    rsuIp,
+    startTime,
+    endTime,
+    intervalMinutes,
+    abortController,
+  }: {
+    token: string
+    rsuIp: string
+    startTime: Date
+    endTime: Date
+    intervalMinutes: number
+    abortController?: AbortController
+  }): Promise<RsuState[] | undefined> {
+    const queryParams: Record<string, string> = {
+      rsuIp,
+      startTime: startTime.getTime().toString(),
+      endTime: endTime.getTime().toString(),
+      intervalMinutes: intervalMinutes.toString(),
+    }
+
+    const response = await authApiHelper.invokeApi({
+      path: `/data/rsu-status/aggregated`,
+      token,
+      queryParams,
+      abortController,
+      failureMessage: 'Failed to fetch aggregated RSU status',
+      tag: 'rsu',
+    })
+
+    return response
+  }
+}
+
+export default new RsuApi()

--- a/webapp/src/features/adminAddRsu/AdminAddRsu.tsx
+++ b/webapp/src/features/adminAddRsu/AdminAddRsu.tsx
@@ -235,7 +235,9 @@ const AdminAddRsu = () => {
             <Grid2 size={6}>
               <Form.Group controlId="primary_route">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="primary_route">Primary Route</InputLabel>
+                  <InputLabel htmlFor="primary_route" required>
+                    Primary Route
+                  </InputLabel>
                   <Select
                     id="primary_route"
                     label="Primary Route"
@@ -299,7 +301,9 @@ const AdminAddRsu = () => {
             <Grid2 size={5}>
               <Form.Group controlId="model">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="model">RSU Model</InputLabel>
+                  <InputLabel htmlFor="model" required>
+                    RSU Model
+                  </InputLabel>
                   <Select
                     id="model"
                     label="RSU Model"
@@ -349,7 +353,9 @@ const AdminAddRsu = () => {
 
           <Form.Group controlId="ssh_credential_group">
             <FormControl fullWidth margin="normal">
-              <InputLabel htmlFor="ssh_credential_group">SSH Credential Group</InputLabel>
+              <InputLabel htmlFor="ssh_credential_group" required>
+                SSH Credential Group
+              </InputLabel>
               <Select
                 id="ssh_credential_group"
                 label="SSH Credential Group"
@@ -378,12 +384,15 @@ const AdminAddRsu = () => {
             <Grid2 size={6}>
               <Form.Group controlId="snmp_credential_group">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="snmp_credential_group">SNMP Credential Group</InputLabel>
+                  <InputLabel htmlFor="snmp_credential_group" required>
+                    SNMP Credential Group
+                  </InputLabel>
                   <Select
                     id="snmp_credential_group"
                     label="SNMP Credential Group"
                     value={selectedSnmpGroup}
                     defaultValue={selectedSnmpGroup}
+                    required
                     onChange={(event) => {
                       const selectedGroup = event.target.value as string
                       dispatch(updateSelectedSnmpGroup(selectedGroup))
@@ -405,7 +414,9 @@ const AdminAddRsu = () => {
             <Grid2 size={6}>
               <Form.Group controlId="snmp_version_group">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="snmp_version_group">SNMP Protocol</InputLabel>
+                  <InputLabel htmlFor="snmp_version_group" required>
+                    SNMP Protocol
+                  </InputLabel>
                   <Select
                     id="snmp_version_group"
                     label="SNMP Protocol"
@@ -433,7 +444,9 @@ const AdminAddRsu = () => {
           </Grid2>
           <Form.Group controlId="organizations">
             <FormControl fullWidth margin="normal">
-              <InputLabel htmlFor="organizations">Organizations</InputLabel>
+              <InputLabel htmlFor="organizations" required>
+                Organizations
+              </InputLabel>
               <Select
                 id="organizations"
                 label="Organizations"

--- a/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
+++ b/webapp/src/features/adminEditRsu/AdminEditRsu.tsx
@@ -323,7 +323,9 @@ const AdminEditRsu = () => {
                 <Grid2 size={6}>
                   <Form.Group controlId="primary_route">
                     <FormControl fullWidth margin="normal">
-                      <InputLabel htmlFor="primary_route">Primary Route</InputLabel>
+                      <InputLabel htmlFor="primary_route" required>
+                        Primary Route
+                      </InputLabel>
                       <Select
                         id="primary_route"
                         label="Primary Route"
@@ -390,7 +392,9 @@ const AdminEditRsu = () => {
                 <Grid2 size={5}>
                   <Form.Group controlId="model">
                     <FormControl fullWidth margin="normal">
-                      <InputLabel htmlFor="model">RSU Model</InputLabel>
+                      <InputLabel htmlFor="model" required>
+                        RSU Model
+                      </InputLabel>
                       <Select
                         id="model"
                         label="RSU Model"
@@ -444,7 +448,9 @@ const AdminEditRsu = () => {
 
               <Form.Group controlId="ssh_credential_group">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="ssh_credential_group">SSH Credential Group</InputLabel>
+                  <InputLabel htmlFor="ssh_credential_group" required>
+                    SSH Credential Group
+                  </InputLabel>
                   <Select
                     id="ssh_credential_group"
                     label="SSH Credential Group"
@@ -473,7 +479,9 @@ const AdminEditRsu = () => {
                 <Grid2 size={6}>
                   <Form.Group controlId="snmp_credential_group">
                     <FormControl fullWidth margin="normal">
-                      <InputLabel htmlFor="snmp_credential_group">SNMP Credential Group</InputLabel>
+                      <InputLabel htmlFor="snmp_credential_group" required>
+                        SNMP Credential Group
+                      </InputLabel>
                       <Select
                         id="snmp_credential_group"
                         label="SNMP Credential Group"
@@ -503,7 +511,9 @@ const AdminEditRsu = () => {
                 <Grid2 size={6}>
                   <Form.Group controlId="snmp_version_group">
                     <FormControl fullWidth margin="normal">
-                      <InputLabel htmlFor="snmp_version_group">SNMP Protocol</InputLabel>
+                      <InputLabel htmlFor="snmp_version_group" required>
+                        SNMP Protocol
+                      </InputLabel>
                       <Select
                         id="snmp_version_group"
                         label="SNMP Protocol"
@@ -532,7 +542,9 @@ const AdminEditRsu = () => {
 
               <Form.Group controlId="organizations">
                 <FormControl fullWidth margin="normal">
-                  <InputLabel htmlFor="organizations">Organizations</InputLabel>
+                  <InputLabel htmlFor="organizations" required>
+                    Organizations
+                  </InputLabel>
                   <Select
                     id="organizations"
                     label="Organizations"

--- a/webapp/src/features/adminRsuTab/AdminRsuTab.tsx
+++ b/webapp/src/features/adminRsuTab/AdminRsuTab.tsx
@@ -15,7 +15,11 @@ import {
   setEditRsuRowData,
 } from './adminRsuTabSlice'
 import { clear, getRsuInfo } from '../adminEditRsu/adminEditRsuSlice'
+import RsuStatusDialog from './RsuStatusDialog'
+import RsuApi, { RsuState } from '../../apis/intersections/rsu-api'
 import { useSelector, useDispatch } from 'react-redux'
+import { selectToken } from '../../generalSlices/userSlice'
+import { debounce } from 'lodash'
 
 import './Admin.css'
 import { AnyAction, ThunkDispatch } from '@reduxjs/toolkit'
@@ -26,11 +30,19 @@ import { NotFound } from '../../pages/404'
 import toast from 'react-hot-toast'
 import { useTheme } from '@mui/material'
 import { DeleteOutline, ModeEditOutline } from '@mui/icons-material'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
 const AdminRsuTab = () => {
   const dispatch: ThunkDispatch<RootState, void, AnyAction> = useDispatch()
   const navigate = useNavigate()
   const theme = useTheme()
+
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false)
+  const [selectedRsuIp, setSelectedRsuIp] = useState<string | null>(null)
+  const [latestRsuState, setLatestRsuState] = useState<RsuState | null>(null)
+  const [historicalRsuData, setHistoricalRsuData] = useState<RsuState[] | null>(null)
+
+  const token = useSelector(selectToken)
 
   const tableData = useSelector(selectTableData)
   const [columns] = useState([
@@ -41,9 +53,65 @@ const AdminRsuTab = () => {
     { title: 'Serial Number', field: 'serial_number', id: 4 },
   ])
 
+  const handleStatusClick = (rowData: AdminEditRsuFormType) => {
+    setSelectedRsuIp(rowData.ip)
+    setStatusDialogOpen(true)
+  }
+
+  const handleStatusDialogClose = () => {
+    setStatusDialogOpen(false)
+    setSelectedRsuIp(null)
+  }
+
+  const debouncedQueryHistoricalData = debounce((selectedDate: string) => {
+    if (selectedRsuIp && selectedDate) {
+      const startTime = new Date(selectedDate).setHours(0, 0, 0, 0)
+      const endTime = new Date(selectedDate).setHours(23, 59, 59, 999)
+
+      RsuApi.getHistoricalRsuStatus({
+        token,
+        rsuIp: selectedRsuIp,
+        startTime: new Date(startTime),
+        endTime: new Date(endTime),
+      })
+        .then((data) => {
+          setHistoricalRsuData(data ?? null)
+        })
+        .catch((err) => {
+          setHistoricalRsuData(null)
+        })
+    }
+  }, 300) // Debounce with 300ms delay
+
   const loading = useSelector(selectLoading)
 
+  React.useEffect(() => {
+    if (statusDialogOpen && selectedRsuIp) {
+      RsuApi.getLatestRsuStatus({ token, rsuIp: selectedRsuIp })
+        .then((data) => {
+          setLatestRsuState(data ?? null)
+        })
+        .catch((err) => {
+          setLatestRsuState(null)
+          console.error('Failed to fetch RSU state:', err)
+        })
+    } else {
+      setLatestRsuState(null)
+    }
+  }, [statusDialogOpen, selectedRsuIp, token])
+
   const tableActions: Action<AdminEditRsuFormType>[] = [
+    {
+      icon: () => <InfoOutlinedIcon sx={{ color: theme.palette.custom.rowActionIcon }} />,
+      tooltip: 'RSU Status',
+      position: 'row',
+      iconProps: {
+        itemType: 'rowAction',
+      },
+      onClick: (event, rowData: AdminEditRsuFormType) => {
+        handleStatusClick(rowData)
+      },
+    },
     {
       icon: () => <ModeEditOutline sx={{ color: theme.palette.custom.rowActionIcon }} />,
       tooltip: 'Edit RSU',
@@ -155,6 +223,12 @@ const AdminRsuTab = () => {
             loading === false && (
               <div className="scroll-div-tab">
                 <AdminTable title={''} data={tableData} columns={columns} actions={tableActions} />
+                <RsuStatusDialog
+                  open={statusDialogOpen}
+                  onClose={handleStatusDialogClose}
+                  rsuIp={selectedRsuIp}
+                  token={token}
+                />
               </div>
             )
           }

--- a/webapp/src/features/adminRsuTab/RsuStatusDialog.tsx
+++ b/webapp/src/features/adminRsuTab/RsuStatusDialog.tsx
@@ -1,0 +1,531 @@
+import React, { useState, useEffect } from 'react'
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  Typography,
+  TextField,
+  IconButton,
+  Button,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  FormControl,
+  InputLabel,
+} from '@mui/material'
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceArea,
+} from 'recharts'
+import { Close } from '@mui/icons-material'
+import RsuApi, { type RsuState } from '../../apis/intersections/rsu-api'
+
+type RsuStatusDialogProps = {
+  open: boolean
+  onClose: () => void
+  rsuIp: string | null
+  token: string
+}
+
+const RsuStatusDialog: React.FC<RsuStatusDialogProps> = ({ open, onClose, rsuIp, token }) => {
+  const [latestRsuState, setLatestRsuState] = useState<RsuState | null>(null)
+  const [historicalData, setHistoricalData] = useState<RsuState[] | null>(null)
+  const [startDate, setStartDate] = useState<string>(new Date().toISOString().split('T')[0])
+  const [endDate, setEndDate] = useState<string>(new Date().toISOString().split('T')[0])
+  const [showCharts, setShowCharts] = useState(false)
+  const [intervalMinutes, setIntervalMinutes] = useState<number>(5)
+  const [chartStartDate, setChartStartDate] = useState<string>(startDate)
+  const [chartEndDate, setChartEndDate] = useState<string>(endDate)
+
+  useEffect(() => {
+    if (open && rsuIp) {
+      // Query latest RSU status
+      RsuApi.getLatestRsuStatus({ token, rsuIp })
+        .then((data) => setLatestRsuState(data ?? null))
+        .catch(() => setLatestRsuState(null))
+    }
+  }, [open, rsuIp, token])
+
+  const handleStartDateChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setStartDate(event.target.value)
+  }
+
+  const handleEndDateChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setEndDate(event.target.value)
+  }
+
+  const handleIntervalChange = (event: SelectChangeEvent<number>) => {
+    setIntervalMinutes(Number(event.target.value))
+  }
+
+  const handleGenerateCharts = () => {
+    const [earlierDate, laterDate] =
+      new Date(startDate) <= new Date(endDate) ? [startDate, endDate] : [endDate, startDate]
+
+    const start = new Date(earlierDate).setUTCHours(0, 0, 0, 0)
+    const end = new Date(laterDate).setUTCHours(23, 59, 59, 999)
+
+    RsuApi.getAggregatedRsuStatus({
+      token,
+      rsuIp,
+      startTime: new Date(start),
+      endTime: new Date(end),
+      intervalMinutes,
+    })
+      .then((data) => {
+        setHistoricalData(data ?? null)
+        setChartStartDate(earlierDate)
+        setChartEndDate(laterDate)
+        setShowCharts(true)
+      })
+      .catch(() => {
+        setHistoricalData(null)
+        setChartStartDate(earlierDate)
+        setChartEndDate(laterDate)
+        setShowCharts(true)
+      })
+  }
+
+  const temperatureData =
+    historicalData?.map((data) => ({
+      time: data.timestamp,
+      value: parseFloat((data.temperature * (9 / 5) + 32).toFixed(1)),
+    })) || []
+
+  const uptimeData =
+    historicalData?.map((data) => ({
+      time: data.timestamp,
+      value: data.uptime,
+    })) || []
+
+  const temperatureDomain = [
+    Math.floor(Math.min(...temperatureData.map((d) => d.value)) / 5) * 5,
+    Math.ceil(Math.max(...temperatureData.map((d) => d.value)) / 5) * 5,
+  ]
+
+  const uptimeDomain = [
+    Math.round(Math.min(...uptimeData.map((d) => d.value)) - 1),
+    Math.round(Math.max(...uptimeData.map((d) => d.value)) + 1),
+  ]
+
+  const timeDomain = [Math.min(...temperatureData.map((d) => d.time)), Math.max(...temperatureData.map((d) => d.time))]
+
+  // Updated formatTimestamp to include hours and minutes for X-axis
+  const formatTimestamp = (unixTime: number) => {
+    const date = new Date(unixTime)
+    return `${date.getUTCMonth() + 1}/${date.getUTCDate()} ${date.getUTCHours()}:${date
+      .getUTCMinutes()
+      .toString()
+      .padStart(2, '0')}` // Format as MM/DD HH:mm in UTC
+  }
+
+  // Define color gradients for charts
+  const redTempTarget = 140
+  const yellowTempTarget = 120
+  const greenTempTarget = 100
+
+  // Offset for red gradient stop based on temperature domain
+  const redOffset = 1 - (redTempTarget - temperatureDomain[0]) / (temperatureDomain[1] - temperatureDomain[0])
+  // Offset for yellow gradient stop based on temperature domain
+  const yellowOffset = 1 - (yellowTempTarget - temperatureDomain[0]) / (temperatureDomain[1] - temperatureDomain[0])
+  // Offset for green gradient stop based on temperature domain
+  const greenOffset = 1 - (greenTempTarget - temperatureDomain[0]) / (temperatureDomain[1] - temperatureDomain[0])
+
+  const yellowUptimeTarget = 7776000 // 90 days in seconds
+  const greenUptimeTarget = yellowUptimeTarget * 0.9 // 90% of yellow target
+
+  // Offset for green uptime gradient stop
+  const greenUptimeOffset = 1 - (greenUptimeTarget - uptimeDomain[0]) / (uptimeDomain[1] - uptimeDomain[0])
+  // Offset for yellow uptime gradient stop
+  const yellowUptimeOffset = 1 - (yellowUptimeTarget - uptimeDomain[0]) / (uptimeDomain[1] - uptimeDomain[0])
+
+  // Identify reboot points (local minima after a decrease)
+  const rebootPoints = uptimeData.reduce((acc, curr, index, arr) => {
+    if (index > 0 && arr[index - 1].value > curr.value) {
+      acc.push(curr.time) // Identify local minima after a decrease as reboot points
+    }
+    return acc
+  }, [])
+
+  // Calculate reboot zones (from local max to subsequent local min)
+  const rebootZones = uptimeData.reduce((zones, curr, index, arr) => {
+    if (index > 0 && arr[index - 1].value > curr.value) {
+      const start = arr[index - 1].time
+      const end = curr.time - curr.value * 1000 // Subtract uptime (in milliseconds) from the current timestamp
+      const durationMs = end - start
+
+      // Format duration into a human-readable string
+      const durationSec = Math.floor(durationMs / 1000)
+      const days = Math.floor(durationSec / 86400)
+      const hours = Math.floor((durationSec % 86400) / 3600)
+      const minutes = Math.floor((durationSec % 3600) / 60)
+
+      let durationLabel = ''
+      if (days > 0) {
+        durationLabel = `${days} day${days > 1 ? 's' : ''}`
+      } else if (hours > 0) {
+        durationLabel = `${hours} hr ${minutes} min`
+      } else {
+        durationLabel = `${minutes} min`
+      }
+
+      zones.push({
+        start,
+        end,
+        label: `Offline ${durationLabel}`,
+      })
+    }
+    return zones
+  }, [])
+
+  // Formats uptime in days and hours
+  const formatUptime = (seconds: number, forTooltip = false) => {
+    const days = Math.floor(seconds / 86400)
+    const hours = Math.floor((seconds % 86400) / 3600)
+
+    if (days > 0 && hours > 0) {
+      return forTooltip ? `${days} days, ${hours} ${hours === 1 ? 'hour' : 'hours'}` : `${days}d ${hours}hr`
+    }
+
+    if (days > 0 && hours === 0) {
+      return forTooltip ? `${days} days` : `${days}d`
+    }
+
+    if (days === 0 && hours > 0) {
+      return forTooltip ? `${hours} ${hours === 1 ? 'hour' : 'hours'}` : `${hours}hr`
+    }
+
+    return forTooltip ? `0 hours` : `0hr`
+  }
+
+  // Updated formatTooltip to include hours and minutes for tooltips
+  const formatTooltip = (value: number, name: string, props: any) => {
+    if (name === 'Time') {
+      const date = new Date(value)
+      return [
+        `${date.getUTCMonth() + 1}/${date.getUTCDate()}/${date.getUTCFullYear()} ${date.getUTCHours()}:${date
+          .getUTCMinutes()
+          .toString()
+          .padStart(2, '0')}`, // Format as MM/DD/YYYY HH:mm in UTC
+        name,
+      ]
+    }
+    if (name === 'Temperature') {
+      return [`${value}°F`, 'Temperature']
+    }
+    if (name === 'Uptime') {
+      return [formatUptime(value, true), 'Uptime']
+    }
+    return [value, name]
+  }
+
+  // Clear and recalculate reboot points and zones whenever the historical data changes
+  useEffect(() => {
+    // Clear reboot points and zones when historical data changes
+    rebootPoints.splice(0, rebootPoints.length)
+    rebootZones.splice(0, rebootZones.length)
+
+    // Recalculate reboot points
+    uptimeData.reduce((acc, curr, index, arr) => {
+      if (index > 0 && arr[index - 1].value > curr.value) {
+        acc.push(curr.time)
+      }
+      return acc
+    }, rebootPoints)
+
+    // Recalculate reboot zones
+    uptimeData.reduce((zones, curr, index, arr) => {
+      if (index > 0 && arr[index - 1].value > curr.value) {
+        const start = arr[index - 1].time
+        const end = curr.time - curr.value * 1000 // Subtract uptime (in milliseconds) from the current timestamp
+        const durationMs = end - start
+
+        // Format duration into a human-readable string
+        const durationSec = Math.floor(durationMs / 1000)
+        const days = Math.floor(durationSec / 86400)
+        const hours = Math.floor((durationSec % 86400) / 3600)
+        const minutes = Math.floor((durationSec % 3600) / 60)
+
+        let durationLabel = ''
+        if (days > 0) {
+          durationLabel = `${days} day${days > 1 ? 's' : ''}`
+        } else if (hours > 0) {
+          durationLabel = `${hours} hr ${minutes} min`
+        } else {
+          durationLabel = `${minutes} min`
+        }
+
+        zones.push({
+          start,
+          end,
+          label: `Offline ${durationLabel}`,
+        })
+      }
+      return zones
+    }, rebootZones)
+  }, [historicalData])
+
+  // Calculate whether to position the box in the top right corner
+  const isEarlyReboot = rebootPoints.some((time) => time < timeDomain[0] + (timeDomain[1] - timeDomain[0]) * 0.4)
+
+  // Set the warning box position dynamically to one of the top corners of the chart
+  const warningBoxWidth = 160 // Width of the warning box in pixels
+  const warningBoxHeight = 80 // Height of the warning box in pixels
+  const warningBoxX = isEarlyReboot ? `calc(98% - ${warningBoxWidth}px)` : 100
+  const warningBoxY = 20 // Keep the Y position constant
+
+  // Adjust the position to align the top-right corner of the box
+
+  // Calculate ticks at 6-hour intervals and include start and end of the time domain
+  const sixHoursInMs = 6 * 60 * 60 * 1000 // 6 hours in milliseconds
+  const startOfFirstInterval = Math.ceil(timeDomain[0] / sixHoursInMs) * sixHoursInMs // Align to the next 6-hour mark
+  const xAxisTicks = []
+
+  // Add 6-hour interval ticks
+  for (let tick = startOfFirstInterval; tick <= timeDomain[1]; tick += sixHoursInMs) {
+    xAxisTicks.push(tick)
+  }
+
+  // Ensure start and end of the time domain are included
+  if (!xAxisTicks.includes(timeDomain[0])) {
+    xAxisTicks.unshift(timeDomain[0])
+  }
+  if (!xAxisTicks.includes(timeDomain[1])) {
+    xAxisTicks.push(timeDomain[1])
+  }
+
+  // Sort ticks to maintain order
+  xAxisTicks.sort((a, b) => a - b)
+
+  const formatChartTitle = (startDate: string, endDate: string, label: string) => {
+    const [start, end] = new Date(startDate) <= new Date(endDate) ? [startDate, endDate] : [endDate, startDate]
+    if (start === end) {
+      return `${label} for ${start.split('-')[1]}/${start.split('-')[2]}/${start.split('-')[0]}`
+    }
+    return `${label} for ${start.split('-')[1]}/${start.split('-')[2]}/${start.split('-')[0]} - ${end.split('-')[1]}/${
+      end.split('-')[2]
+    }/${end.split('-')[0]}`
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xl" fullWidth>
+      <DialogTitle>
+        {`Status of RSU at ${rsuIp || 'unknown IP'}`}
+        <IconButton onClick={onClose} style={{ position: 'absolute', right: 8, top: 8 }}>
+          <Close />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <Typography variant="subtitle2">
+          {latestRsuState
+            ? `Last status update: ${new Date(latestRsuState.timestamp).toUTCString()} (${formatUptime(
+                Math.floor((Date.now() - latestRsuState.timestamp) / 1000),
+                true
+              )} ago)`
+            : 'No RSU status data.'}
+        </Typography>
+        <Typography variant="subtitle2">
+          {latestRsuState
+            ? `Last reboot: ${new Date(
+                latestRsuState.timestamp - latestRsuState.uptime * 1000
+              ).toUTCString()} (${formatUptime(
+                Math.floor((Date.now() - (latestRsuState.timestamp - latestRsuState.uptime * 1000)) / 1000),
+                true
+              )} ago)`
+            : 'No RSU reboot data.'}
+        </Typography>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', margin: '24px 0 16px' }}>
+          <div style={{ display: 'flex', gap: '0px', margin: '0px 0' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+              <Typography variant="subtitle2">Start Date</Typography>
+              <TextField
+                type="date"
+                value={startDate}
+                onChange={handleStartDateChange}
+                InputLabelProps={{ shrink: true }}
+                fullWidth
+              />
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+              <Typography variant="subtitle2">End Date</Typography>
+              <TextField
+                type="date"
+                value={endDate}
+                onChange={handleEndDateChange}
+                InputLabelProps={{ shrink: true }}
+                fullWidth
+              />
+            </div>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '16px', margin: '10px 0' }}>
+            <div style={{ display: 'flex', flexDirection: 'column', maxWidth: '150px' }}>
+              <Typography variant="subtitle2">Interval</Typography>
+              <FormControl>
+                <Select value={intervalMinutes} onChange={handleIntervalChange}>
+                  <MenuItem value={5}>5 minutes</MenuItem>
+                  <MenuItem value={10}>10 minutes</MenuItem>
+                  <MenuItem value={15}>15 minutes</MenuItem>
+                  <MenuItem value={30}>30 minutes</MenuItem>
+                  <MenuItem value={60}>1 hour</MenuItem>
+                  <MenuItem value={240}>4 hours</MenuItem>
+                  <MenuItem value={360}>6 hours</MenuItem>
+                  <MenuItem value={720}>12 hours</MenuItem>
+                  <MenuItem value={1440}>24 hours</MenuItem>
+                </Select>
+              </FormControl>
+            </div>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleGenerateCharts}
+              style={{ padding: '10px', fontSize: '16px' }}
+            >
+              Generate
+            </Button>
+          </div>
+        </div>
+
+        {showCharts && (
+          <>
+            <Typography variant="h6">{formatChartTitle(chartStartDate, chartEndDate, 'Temperature')}</Typography>
+            <ResponsiveContainer width="100%" height={300}>
+              <ScatterChart margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                <defs>
+                  <linearGradient id="temperatureGradient" x1="0" y1="0" x2="0" y2="1">
+                    {yellowTempTarget < temperatureDomain[1] && <stop offset={`${redOffset}`} stopColor="#ca8282" />}
+                    <stop offset={`${yellowOffset}`} stopColor="#f0e68c" />
+                    {yellowTempTarget > temperatureDomain[0] && <stop offset={`${greenOffset}`} stopColor="#82ca9d" />}
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="time"
+                  domain={timeDomain}
+                  name="Time"
+                  tickFormatter={formatTimestamp}
+                  type="number"
+                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5 }}
+                  ticks={xAxisTicks} // Use calculated ticks including start and end
+                />
+                <YAxis
+                  dataKey="value"
+                  domain={temperatureDomain}
+                  name="Temperature"
+                  label={{ value: 'Temperature (°F)', angle: -90, position: 'center', dx: -20 }}
+                  ticks={Array.from(
+                    { length: (temperatureDomain[1] - temperatureDomain[0]) / 5 + 1 },
+                    (_, i) => temperatureDomain[0] + i * 5
+                  )}
+                />
+                <Tooltip isAnimationActive={false} formatter={formatTooltip} />
+                <Scatter
+                  data={temperatureData}
+                  line={{ stroke: 'url(#temperatureGradient)', strokeWidth: 3 }}
+                  fill="rgba(0, 0, 0, 0)"
+                  lineJointType="monotoneX"
+                />
+              </ScatterChart>
+            </ResponsiveContainer>
+
+            <Typography variant="h6">{formatChartTitle(chartStartDate, chartEndDate, 'Uptime')}</Typography>
+            <ResponsiveContainer width="100%" height={300}>
+              <ScatterChart margin={{ top: 10, right: 10, bottom: 20, left: 10 }}>
+                <defs>
+                  <linearGradient id="uptimeGradient" x1="0" y1="0" x2="0" y2="1">
+                    {yellowUptimeTarget <= uptimeDomain[1] && (
+                      <stop offset={`${yellowUptimeOffset}`} stopColor="#f0e68c" />
+                    )}
+                    {yellowUptimeTarget >= uptimeDomain[0] && (
+                      <stop offset={`${greenUptimeOffset}`} stopColor="#82ca9d" />
+                    )}
+                    <stop offset={`${greenUptimeOffset}`} stopColor="#82ca9d" />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis
+                  dataKey="time"
+                  domain={timeDomain}
+                  name="Time"
+                  tickFormatter={formatTimestamp}
+                  type="number"
+                  label={{ value: 'Time (UTC)', position: 'insideBottom', offset: -5 }}
+                  ticks={xAxisTicks} // Use calculated ticks including start and end
+                />
+                <YAxis
+                  dataKey="value"
+                  domain={uptimeDomain}
+                  name="Uptime"
+                  label={{ value: 'Uptime', angle: -90, position: 'center', dx: -40 }}
+                  tickFormatter={(value) => formatUptime(value)}
+                  ticks={Array.from(
+                    { length: (uptimeDomain[1] - uptimeDomain[0]) / 5 + 1 },
+                    (_, i) => uptimeDomain[0] + i * 5
+                  )}
+                  width={80}
+                />
+                <Tooltip isAnimationActive={false} formatter={formatTooltip} />
+                {/* Render shaded areas for reboot zones with labels starting at the right end */}
+                {rebootZones.map((zone, index) => (
+                  <ReferenceArea
+                    key={index}
+                    x1={zone.start}
+                    x2={zone.end}
+                    stroke="red"
+                    strokeOpacity={0.3}
+                    fill="red"
+                    fillOpacity={0.1}
+                    label={{
+                      value: zone.label,
+                      position: 'insideRight',
+                      fill: 'red',
+                      fontSize: 14,
+                      angle: 90,
+                      dy: 0,
+                      dx: 20,
+                    }}
+                  />
+                ))}
+                <Scatter
+                  data={uptimeData}
+                  line={{ stroke: 'url(#uptimeGradient)', strokeWidth: 3 }}
+                  fill="rgba(0, 0, 0, 0)"
+                  lineJointType="monotoneX"
+                />
+                {/* Conditional textbox for warning */}
+                {yellowUptimeTarget < uptimeDomain[1] && (
+                  <foreignObject x={warningBoxX} y={warningBoxY} width={warningBoxWidth} height={warningBoxHeight}>
+                    <div
+                      style={{
+                        border: '2px solid black',
+                        backgroundColor: 'white',
+                        padding: '5px',
+                        borderRadius: '5px',
+                        fontSize: '14px',
+                        fontWeight: 'bold',
+                        whiteSpace: 'pre-wrap',
+                      }}
+                    >
+                      Yellow indicates more
+                      <br />
+                      than 90 days since
+                      <br />
+                      previous reboot.
+                    </div>
+                  </foreignObject>
+                )}
+              </ScatterChart>
+            </ResponsiveContainer>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default RsuStatusDialog

--- a/webapp/src/pages/Map.tsx
+++ b/webapp/src/pages/Map.tsx
@@ -125,6 +125,8 @@ import { Feature, Point } from 'geojson'
 import { PrimaryButton } from '../styles/components/PrimaryButton'
 import { ConditionalRenderRsu, evaluateFeatureFlags } from '../feature-flags'
 import { DateTime } from 'luxon'
+import RsuStatusDialog from '../features/adminRsuTab/RsuStatusDialog'
+import { selectToken } from '../generalSlices/userSlice'
 
 // eslint-disable-next-line
 // eslint-disable-next-line import/no-webpack-loader-syntax, @typescript-eslint/no-require-imports
@@ -915,6 +917,17 @@ function MapPage() {
     return { value: type, label: type }
   })
 
+  // Added logic to open RsuStatusDialog from Map popup
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false)
+  const [selectedRsuIp, setSelectedRsuIp] = useState<string | null>(null)
+
+  const token = useSelector(selectToken)
+
+  const handlePopupClick = (rsuIp: string) => {
+    setSelectedRsuIp(rsuIp)
+    setStatusDialogOpen(true)
+  }
+
   return (
     <div className="container">
       <div className="menu-container map-control-container">
@@ -1540,6 +1553,9 @@ function MapPage() {
                     {selectedRsu.properties.serial_number ? selectedRsu.properties.serial_number : 'Unknown'}
                   </Typography>
                 </Box>
+                <Button onClick={() => handlePopupClick(selectedRsu.properties.ipv4_address)}>
+                  View RSU Status Charts
+                </Button>
               </Stack>
             </Popup>
           ) : null}
@@ -1810,6 +1826,12 @@ function MapPage() {
             </div>
           </Paper>
         ))}
+      <RsuStatusDialog
+        open={statusDialogOpen}
+        onClose={() => setStatusDialogOpen(false)}
+        rsuIp={selectedRsuIp}
+        token={token}
+      />
     </div>
   )
 }


### PR DESCRIPTION
<!--- Thanks for the contribution! -->

# PR Details

## Description

These changes add the RsuStatusDialog, which displays graphs representing an RSU's status over a selectable time range.

When the dialog is opened for a specific RSU, the dialog first shows the time of the last status and last reboot recorded by the system, then allows the user to select a start date, end date, and an interval between datapoints, ranging between 5 minutes and 24 hours. 
<img width="973" height="397" alt="image" src="https://github.com/user-attachments/assets/53ec56fa-56cf-4e55-aae5-2fc2cef2861c" />

When the user clicks "Generate", line graphs displaying the uptime and temperature data appear within the dialog. Color coding indicates outstanding uptime or temperature levels. After 90 days of constant uptime, the line turns yellow and a text box appears to explain the change. 

In case of an uptime reset, the visualizer also calculates how long the RSU was powered off, and highlights that time in red on the graph.

<img width="755" height="320" alt="image" src="https://github.com/user-attachments/assets/61c1ef6a-df06-4422-92cb-d7e4205a59cf" />

<img width="760" height="330" alt="image" src="https://github.com/user-attachments/assets/e29c6567-1e62-4be7-9407-222fb1ead671" />

<img width="753" height="332" alt="image" src="https://github.com/user-attachments/assets/54c8b72b-16d3-4f53-85c1-09b31d63ab2a" />

<img width="764" height="335" alt="image" src="https://github.com/user-attachments/assets/b2db6f42-c15b-47e8-9edc-189ede6edf93" />

The RsuStatuDialog can either be accessed from the Map from the RSU-selected toolbar, or by clicking the "information" icon on the Admin Rsu management page.

<img width="461" height="375" alt="image" src="https://github.com/user-attachments/assets/e891159c-3b94-4a67-86d3-75c2def93368" />

<img width="741" height="521" alt="image" src="https://github.com/user-attachments/assets/c15cd550-d948-40d8-9b3a-0b32ef8fff1e" />

While making this change, I also found that when adding a new RSU, several fields in the RsuAddDialog and RsuEditDialog did not have the Required (*) indicator, but would throw errors if I attempted to leave them blank. I've added the "required" prop to these fields to reduce confusion.

## How Has This Been Tested?

I tested this in Docker, by importing a "CV.IntersectionApiRsuStatus" dataset manually into MongoDb, then adding a virtual RSU in the Admin panel matching the data's RSU IP. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If a section applies, ensure you have met all of the associated checks -->

- [ ] My changes require new environment variables:
  - [ ] I have updated the docker-compose, K8s YAML, and all dependent deployment configuration files.
- [ ] My changes require updates to the documentation:
  - [ ] I have updated the documentation accordingly.
- [x] My changes require updates and/or additions to the unit tests:
  - [ ] I have modified/added tests to cover my changes.
- [ ] All existing tests pass.
